### PR TITLE
Cloud platform support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,12 @@
 						</filter>
 					</filters>
 					<!-- Additional configuration. -->
+					<relocations>
+						<relocation>
+							<pattern>com.google</pattern>
+							<shadedPattern>org.janelia.saalfeldlab.com.google</shadedPattern>
+						</relocation>
+					</relocations>
 				</configuration>
 				<!-- binds by default to package phase -->
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-aws-s3</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
-			
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -146,6 +145,10 @@
 				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -157,13 +160,18 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-viewer_fiji</artifactId>
-			<version>1.1.1-SNAPSHOT</version>
+			<version>1.2.0-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-spark</artifactId>
 			<version>1.0.1-SNAPSHOT</version>
-			
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,17 @@
 					<artifactId>spark-core_2.11</artifactId>
 					<version>2.1.0</version>
 					<scope>provided</scope>
+					
+					<exclusions>
+						<exclusion>
+							<groupId>org.slf4j</groupId>
+							<artifactId>slf4j-log4j12</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>log4j</groupId>
+							<artifactId>log4j</artifactId>
+						</exclusion>
+					</exclusions>
 				</dependency>
 			</dependencies>
 		</profile>
@@ -50,12 +61,23 @@
 					<groupId>org.apache.spark</groupId>
 					<artifactId>spark-core_2.11</artifactId>
 					<version>2.1.0</version>
+					
+					<exclusions>
+						<exclusion>
+							<groupId>org.slf4j</groupId>
+							<artifactId>slf4j-log4j12</artifactId>
+						</exclusion>
+						<exclusion>
+							<groupId>log4j</groupId>
+							<artifactId>log4j</artifactId>
+						</exclusion>
+					</exclusions>
 				</dependency>
 			</dependencies>
 		</profile>
 	</profiles>
-
-	<dependencies>
+	
+	<dependencies> 
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>Stitching_</artifactId>
@@ -115,6 +137,17 @@
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-aws-s3</artifactId>
 			<version>0.0.1-SNAPSHOT</version>
+			
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
@@ -130,6 +163,17 @@
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-spark</artifactId>
 			<version>1.0.1-SNAPSHOT</version>
+			
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,9 @@
 						<relocation>
 							<pattern>com.google</pattern>
 							<shadedPattern>org.janelia.saalfeldlab.com.google</shadedPattern>
+							<excludes>
+								<exclude>com.google.api.client.auth.oauth2.StoredCredential</exclude>
+							</excludes>
 						</relocation>
 					</relocations>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 				<dependency>
 					<groupId>org.apache.spark</groupId>
 					<artifactId>spark-core_2.11</artifactId>
-					<version>2.1.0</version>
+					<version>2.2.0</version>
 					<scope>provided</scope>
 					
 					<exclusions>
@@ -60,7 +60,7 @@
 				<dependency>
 					<groupId>org.apache.spark</groupId>
 					<artifactId>spark-core_2.11</artifactId>
-					<version>2.1.0</version>
+					<version>2.2.0</version>
 					
 					<exclusions>
 						<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-viewer_fiji</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,17 @@
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-google-cloud</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
 			<version>1.0.0</version>
 		</dependency>

--- a/scripts/spark-janelia/export.py
+++ b/scripts/spark-janelia/export.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '105'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/flatfield.py
+++ b/scripts/spark-janelia/flatfield.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '105'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/mip-n5.py
+++ b/scripts/spark-janelia/mip-n5.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '105'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/remove-dir.py
+++ b/scripts/spark-janelia/remove-dir.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '105'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/slice-tiff-n5.py
+++ b/scripts/spark-janelia/slice-tiff-n5.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '115'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/stitch.py
+++ b/scripts/spark-janelia/stitch.py
@@ -11,7 +11,7 @@ bin_path = os.path.join(base_folder, bin_file)
 flintstone_file = os.path.join('flintstone', 'flintstone.sh')
 flintstone_path = os.path.join(curr_script_dir, flintstone_file)
 
-os.environ['SPARK_VERSION'] = '2'
+os.environ['SPARK_VERSION'] = 'test'
 os.environ['N_DRIVER_THREADS'] = '2'
 os.environ['MEMORY_PER_NODE'] = '105'
 os.environ['TERMINATE'] = '1'

--- a/scripts/spark-janelia/util/add-nodes.py
+++ b/scripts/spark-janelia/util/add-nodes.py
@@ -8,7 +8,7 @@ curr_script_dir = os.path.dirname(os.path.realpath(__file__))
 spark_janelia_file = os.path.join('flintstone', 'spark-janelia', 'spark-janelia-lsf')
 spark_janelia_path = os.path.join(os.path.dirname(curr_script_dir), spark_janelia_file)
 
-spark_version = '2'
+spark_version = 'test'
 
 master_id = int(sys.argv[1])
 nodes = int(sys.argv[2])

--- a/scripts/spark-local/cloud/upload-tiles-n5.py
+++ b/scripts/spark-local/cloud/upload-tiles-n5.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+
+curr_script_dir = os.path.dirname(os.path.realpath(__file__))
+base_folder = os.path.dirname(os.path.dirname(os.path.dirname(curr_script_dir)))
+bin_file = os.path.join('target', 'stitching-spark-0.0.1-SNAPSHOT.jar')
+bin_path = os.path.join(base_folder, bin_file)
+
+subprocess.call(['java', '-Dspark.master=local[*]', '-cp', bin_path, 'org.janelia.stitching.TilesToN5Converter'] + sys.argv[1:])

--- a/src/main/java/net/imglib2/img/list/WrappedListImg.java
+++ b/src/main/java/net/imglib2/img/list/WrappedListImg.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.list;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imglib2.img.Img;
+import net.imglib2.type.Type;
+
+/**
+ * This {@link Img} stores an image in a single linear {@link ArrayList}. Each
+ * pixel is stored as an individual object, so {@link ListImg} should only be
+ * used for images with relatively few pixels. In principle, the number of
+ * entities stored is limited to {@link Integer#MAX_VALUE}.
+ *
+ * Instead of copying references from the given list to a privately allocated container,
+ * this modification wraps the given list, so the updated data can be reused
+ * without having to copy it back.
+ *
+ * @param <T>
+ *            The value type of the pixels. You can us {@link Type}s or
+ *            arbitrary {@link Object}s. If you use non-{@link Type} pixels,
+ *            note, that you cannot use {@link Type#set(Type)} to change the
+ *            value stored in every reference. Instead, you can use the
+ *            {@link ListCursor#set(Object)} and
+ *            {@link ListRandomAccess#set(Object)} methods to alter the
+ *            underlying {@link ArrayList}.
+ *
+ * @author Stephan Preibisch
+ * @author Stephan Saalfeld
+ * @author Tobias Pietzsch
+ * @author Igor Pisarev
+ */
+public class WrappedListImg< T > extends AbstractListImg< T >
+{
+	final private List< T > pixels;
+
+	public WrappedListImg( final List< T > list, final long... dim )
+	{
+		super( dim );
+
+		assert numPixels == list.size() : "Dimensions do not match number of pixels.";
+
+		pixels = list;
+	}
+
+	@Override
+	protected T get( final int index )
+	{
+		return pixels.get( index );
+	}
+
+	@Override
+	protected void set( final int index, final T value )
+	{
+		pixels.set( index, value );
+	}
+
+	@Override
+	public WrappedListImg< T > copy()
+	{
+		return new WrappedListImg< >( pixels, dimension );
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
@@ -99,7 +99,7 @@ class AmazonS3DataProvider implements DataProvider
 	public URI getUri( final String path ) throws URISyntaxException
 	{
 		final URI uri = new URI( path );
-		if ( s3Protocol.equals( uri.getScheme() ) )
+		if ( s3Protocol.equalsIgnoreCase( uri.getScheme() ) )
 			return uri;
 		return new URI( s3Protocol, null, path );
 	}

--- a/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
@@ -148,6 +148,24 @@ class AmazonS3DataProvider implements DataProvider
 	}
 
 	@Override
+	public void copyFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		final AmazonS3URI s3UriSrc = decodeS3Uri( uriSrc );
+		final AmazonS3URI s3UriDst = decodeS3Uri( uriDst );
+		s3.copyObject(
+				s3UriSrc.getBucket(), s3UriSrc.getKey(),
+				s3UriDst.getBucket(), s3UriDst.getKey()
+			);
+	}
+
+	@Override
+	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		copyFile( uriSrc, uriDst );
+		deleteFile( uriSrc );
+	}
+
+	@Override
 	public InputStream getInputStream( final URI uri ) throws IOException
 	{
 		final AmazonS3URI s3Uri = decodeS3Uri( uri );

--- a/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/AmazonS3DataProvider.java
@@ -54,7 +54,6 @@ class AmazonS3DataProvider implements DataProvider
 
 		public S3ObjectOutputStream( final AmazonS3URI uri )
 		{
-	        super();
 	        this.uri = uri;
 	    }
 
@@ -68,13 +67,12 @@ class AmazonS3DataProvider implements DataProvider
 
 				final ObjectMetadata objectMetadata = new ObjectMetadata();
 				objectMetadata.setContentLength( bytes.length );
-
 				try ( final InputStream data = new ByteArrayInputStream( bytes ) )
 				{
 					s3.putObject( uri.getBucket(), uri.getKey(), data, objectMetadata );
 				}
-				super.close();
 
+				super.close();
 				closed = true;
 			}
 		}

--- a/src/main/java/org/janelia/dataaccess/CloudURI.java
+++ b/src/main/java/org/janelia/dataaccess/CloudURI.java
@@ -1,0 +1,65 @@
+package org.janelia.dataaccess;
+
+import java.net.URI;
+
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
+import org.janelia.saalfeldlab.n5.bdv.DataAccessFactory.DataAccessType;
+
+import com.amazonaws.services.s3.AmazonS3URI;
+
+public class CloudURI
+{
+	final AmazonS3URI s3Uri;
+	final GoogleCloudStorageURI googleCloudUri;
+
+	public CloudURI( final URI uri )
+	{
+		// try parsing as s3 link first
+		AmazonS3URI s3Uri;
+		try
+		{
+			s3Uri = new AmazonS3URI( uri );
+		}
+		catch ( final Exception e )
+		{
+			s3Uri = null;
+		}
+
+		if ( s3Uri != null )
+		{
+			this.s3Uri = s3Uri;
+			this.googleCloudUri = null;
+		}
+		else
+		{
+			// might be a google cloud link
+			final GoogleCloudStorageURI googleCloudUri;
+			try
+			{
+				googleCloudUri = new GoogleCloudStorageURI( uri );
+			}
+			catch ( final Exception e )
+			{
+				throw new IllegalArgumentException( "The link should point to AWS S3 or Google Cloud Storage." );
+			}
+
+			this.s3Uri = null;
+			this.googleCloudUri = googleCloudUri;
+		}
+	}
+
+	public DataAccessType getType()
+	{
+		return s3Uri != null ? DataAccessType.AMAZON_S3 : DataAccessType.GOOGLE_CLOUD;
+	}
+
+	public String getBucket()
+	{
+		return s3Uri != null ? s3Uri.getBucket() : googleCloudUri.getBucket();
+	}
+
+	public String getKey()
+	{
+		return s3Uri != null ? s3Uri.getKey() : googleCloudUri.getKey();
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/CloudURI.java
+++ b/src/main/java/org/janelia/dataaccess/CloudURI.java
@@ -3,7 +3,6 @@ package org.janelia.dataaccess;
 import java.net.URI;
 
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
-import org.janelia.saalfeldlab.n5.bdv.DataAccessFactory.DataAccessType;
 
 import com.amazonaws.services.s3.AmazonS3URI;
 
@@ -48,9 +47,9 @@ public class CloudURI
 		}
 	}
 
-	public DataAccessType getType()
+	public DataProviderType getType()
 	{
-		return s3Uri != null ? DataAccessType.AMAZON_S3 : DataAccessType.GOOGLE_CLOUD;
+		return s3Uri != null ? DataProviderType.AMAZON_S3 : DataProviderType.GOOGLE_CLOUD;
 	}
 
 	public String getBucket()

--- a/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
+++ b/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
@@ -37,10 +37,10 @@ class CustomURLStreamHandlerFactory implements URLStreamHandlerFactory
 	@Override
 	public URLStreamHandler createURLStreamHandler( final String protocol )
 	{
-		if ( protocol.equals( s3Protocol ) )
+		if ( protocol.equalsIgnoreCase( s3Protocol ) )
 			return new S3URLStreamHandler( s3 );
 
-		if ( protocol.equals( googleCloudProtocol ) )
+		if ( protocol.equalsIgnoreCase( googleCloudProtocol ) )
 			return new GoogleCloudStorageURLStreamHandler( googleCloudStorage );
 
 		return null;

--- a/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
+++ b/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
@@ -5,6 +5,7 @@ import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.google.cloud.storage.Storage;
 
 /**
  * Factory for all supported custom protocols.
@@ -17,17 +18,20 @@ import com.amazonaws.services.s3.AmazonS3;
 class CustomURLStreamHandlerFactory implements URLStreamHandlerFactory
 {
 	private static final String s3Protocol = "s3";
+	private static final String googleCloudProtocol = "gs";
 
 	private final AmazonS3 s3;
+	private final Storage googleCloudStorage;
 
-	private CustomURLStreamHandlerFactory( final AmazonS3 s3 )
+	private CustomURLStreamHandlerFactory( final AmazonS3 s3, final Storage googleCloudStorage )
 	{
 		this.s3 = s3;
+		this.googleCloudStorage = googleCloudStorage;
 	}
 
-	public synchronized static void init( final AmazonS3 s3 )
+	public synchronized static void init( final AmazonS3 s3, final Storage googleCloudStorage )
 	{
-		URL.setURLStreamHandlerFactory( new CustomURLStreamHandlerFactory( s3 ) );
+		URL.setURLStreamHandlerFactory( new CustomURLStreamHandlerFactory( s3, googleCloudStorage ) );
 	}
 
 	@Override
@@ -35,6 +39,10 @@ class CustomURLStreamHandlerFactory implements URLStreamHandlerFactory
 	{
 		if ( protocol.equals( s3Protocol ) )
 			return new S3URLStreamHandler( s3 );
+
+		if ( protocol.equals( googleCloudProtocol ) )
+			return new GoogleCloudStorageURLStreamHandler( googleCloudStorage );
+
 		return null;
 	}
 }

--- a/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
+++ b/src/main/java/org/janelia/dataaccess/CustomURLStreamHandlerFactory.java
@@ -4,6 +4,9 @@ import java.net.URL;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 
+import org.janelia.dataaccess.googlecloud.GoogleCloudStorageURLStreamHandler;
+import org.janelia.dataaccess.s3.S3URLStreamHandler;
+
 import com.amazonaws.services.s3.AmazonS3;
 import com.google.cloud.storage.Storage;
 

--- a/src/main/java/org/janelia/dataaccess/DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/DataProvider.java
@@ -28,6 +28,9 @@ public interface DataProvider
 
 	public boolean fileExists( final URI uri ) throws IOException;
 
+	public void copyFile( final URI uriSrc, final URI uriDst ) throws IOException;
+	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException;
+
 	public void deleteFile( final URI uri ) throws IOException;
 	public void deleteFolder( final URI uri ) throws IOException;
 

--- a/src/main/java/org/janelia/dataaccess/DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/DataProvider.java
@@ -29,7 +29,10 @@ public interface DataProvider
 	public boolean fileExists( final URI uri ) throws IOException;
 
 	public void copyFile( final URI uriSrc, final URI uriDst ) throws IOException;
+	public void copyFolder( final URI uriSrc, final URI uriDst ) throws IOException;
+
 	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException;
+	public void moveFolder( final URI uriSrc, final URI uriDst ) throws IOException;
 
 	public void deleteFile( final URI uri ) throws IOException;
 	public void deleteFolder( final URI uri ) throws IOException;

--- a/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
@@ -3,6 +3,8 @@ package org.janelia.dataaccess;
 import java.net.URI;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.janelia.dataaccess.googlecloud.GoogleCloudDataProvider;
+import org.janelia.dataaccess.s3.AmazonS3DataProvider;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;

--- a/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import org.apache.commons.lang.NotImplementedException;
 import org.janelia.dataaccess.googlecloud.GoogleCloudDataProvider;
 import org.janelia.dataaccess.s3.AmazonS3DataProvider;
+import org.janelia.saalfeldlab.n5.bdv.DataAccessFactory.DataAccessType;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -117,6 +118,25 @@ public abstract class DataProviderFactory
 		default:
 			throw new NotImplementedException( "Data provider of type " + type + " is not implemented" );
 		}
+	}
+
+	public static URI createBucketUri( final DataAccessType type, final String bucketName )
+	{
+		final String protocol;
+		switch ( type )
+		{
+		case AMAZON_S3:
+			protocol = s3Protocol;
+			break;
+		case GOOGLE_CLOUD:
+			protocol = googleCloudProtocol;
+			break;
+		case FILESYSTEM:
+			throw new IllegalArgumentException( "Not supported for filesystem storage" );
+		default:
+			throw new NotImplementedException( "Not implemented for type " + type );
+		}
+		return URI.create( protocol + "://" + bucketName + "/" );
 	}
 
 	private synchronized static void init( final AmazonS3 s3, final Storage googleCloudStorage )

--- a/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
@@ -85,13 +85,13 @@ public abstract class DataProviderFactory
 	{
 		final String protocol = uri.getScheme();
 
-		if ( protocol == null || protocol.equals( localFileProtocol ) )
+		if ( protocol == null || protocol.equalsIgnoreCase( localFileProtocol ) )
 			return createFSDataProvider();
 
-		if ( protocol.equals( s3Protocol ) )
+		if ( protocol.equalsIgnoreCase( s3Protocol ) )
 			return createAmazonS3DataProvider();
 
-		if ( protocol.equals( googleCloudProtocol ) )
+		if ( protocol.equalsIgnoreCase( googleCloudProtocol ) )
 			return createGoogleCloudDataProvider();
 
 		throw new NotImplementedException( "factory for protocol " + uri.getScheme() + " is not implemented" );

--- a/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
@@ -86,18 +86,7 @@ public abstract class DataProviderFactory
 	 */
 	public static DataProvider createByURI( final URI uri )
 	{
-		final String protocol = uri.getScheme();
-
-		if ( protocol == null || protocol.equalsIgnoreCase( localFileProtocol ) )
-			return createFSDataProvider();
-
-		if ( protocol.equalsIgnoreCase( s3Protocol ) )
-			return createAmazonS3DataProvider();
-
-		if ( protocol.equalsIgnoreCase( googleCloudProtocol ) )
-			return createGoogleCloudDataProvider();
-
-		throw new NotImplementedException( "factory for protocol " + uri.getScheme() + " is not implemented" );
+		return createByType( getTypeByURI( uri ) );
 	}
 
 	/**
@@ -118,6 +107,22 @@ public abstract class DataProviderFactory
 		default:
 			throw new NotImplementedException( "Data provider of type " + type + " is not implemented" );
 		}
+	}
+
+	public static DataProviderType getTypeByURI( final URI uri )
+	{
+		final String protocol = uri.getScheme();
+
+		if ( protocol == null || protocol.equalsIgnoreCase( localFileProtocol ) )
+			return DataProviderType.FILESYSTEM;
+
+		if ( protocol.equalsIgnoreCase( s3Protocol ) )
+			return DataProviderType.AMAZON_S3;
+
+		if ( protocol.equalsIgnoreCase( googleCloudProtocol ) )
+			return DataProviderType.GOOGLE_CLOUD;
+
+		throw new NotImplementedException( "factory for protocol " + uri.getScheme() + " is not implemented" );
 	}
 
 	public static URI createBucketUri( final DataAccessType type, final String bucketName )

--- a/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderFactory.java
@@ -5,7 +5,6 @@ import java.net.URI;
 import org.apache.commons.lang.NotImplementedException;
 import org.janelia.dataaccess.googlecloud.GoogleCloudDataProvider;
 import org.janelia.dataaccess.s3.AmazonS3DataProvider;
-import org.janelia.saalfeldlab.n5.bdv.DataAccessFactory.DataAccessType;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -125,7 +124,7 @@ public abstract class DataProviderFactory
 		throw new NotImplementedException( "factory for protocol " + uri.getScheme() + " is not implemented" );
 	}
 
-	public static URI createBucketUri( final DataAccessType type, final String bucketName )
+	public static URI createBucketUri( final DataProviderType type, final String bucketName )
 	{
 		final String protocol;
 		switch ( type )

--- a/src/main/java/org/janelia/dataaccess/DataProviderType.java
+++ b/src/main/java/org/janelia/dataaccess/DataProviderType.java
@@ -3,5 +3,6 @@ package org.janelia.dataaccess;
 public enum DataProviderType
 {
 	FILESYSTEM,
-	AMAZON_S3
+	AMAZON_S3,
+	GOOGLE_CLOUD
 }

--- a/src/main/java/org/janelia/dataaccess/FSDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/FSDataProvider.java
@@ -94,12 +94,24 @@ class FSDataProvider implements DataProvider
 	}
 
 	@Override
+	public void copyFolder( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		copyFile( uriSrc, uriDst );
+	}
+
+	@Override
 	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException
 	{
 		Files.move(
 				getPath( uriSrc ),
 				getPath( uriDst )
 			);
+	}
+
+	@Override
+	public void moveFolder( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		moveFile( uriSrc, uriDst );
 	}
 
 	@Override

--- a/src/main/java/org/janelia/dataaccess/FSDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/FSDataProvider.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import org.janelia.saalfeldlab.n5.N5;
@@ -87,7 +88,8 @@ class FSDataProvider implements DataProvider
 	{
 		Files.copy(
 				getPath( uriSrc ),
-				getPath( uriDst )
+				getPath( uriDst ),
+				StandardCopyOption.REPLACE_EXISTING
 			);
 	}
 

--- a/src/main/java/org/janelia/dataaccess/FSDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/FSDataProvider.java
@@ -83,6 +83,24 @@ class FSDataProvider implements DataProvider
 	}
 
 	@Override
+	public void copyFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		Files.copy(
+				Paths.get( uriSrc.toString() ),
+				Paths.get( uriDst.toString() )
+			);
+	}
+
+	@Override
+	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		Files.move(
+				Paths.get( uriSrc.toString() ),
+				Paths.get( uriDst.toString() )
+			);
+	}
+
+	@Override
 	public InputStream getInputStream( final URI uri) throws IOException
 	{
 		return new FileInputStream( uri.toString() );

--- a/src/main/java/org/janelia/dataaccess/GoogleCloudDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/GoogleCloudDataProvider.java
@@ -1,0 +1,221 @@
+package org.janelia.dataaccess;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.googlecloud.N5GoogleCloudStorage;
+import org.janelia.stitching.Utils;
+import org.janelia.util.ImageImporter;
+
+import com.google.api.gax.paging.Page;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.Storage.CopyRequest;
+import com.google.gson.GsonBuilder;
+
+import ij.IJ;
+import ij.ImagePlus;
+
+class GoogleCloudDataProvider implements DataProvider
+{
+	private class BlobOutputStream extends ByteArrayOutputStream
+	{
+		private final GoogleCloudStorageURI uri;
+		private boolean closed;
+
+		public BlobOutputStream( final GoogleCloudStorageURI uri )
+		{
+	        this.uri = uri;
+	    }
+
+		@Override
+		public void close() throws IOException
+		{
+			if ( !closed )
+			{
+				super.flush();
+				final byte[] bytes = toByteArray();
+
+				final BlobInfo blobInfo = BlobInfo.newBuilder( uri.getBucket(), uri.getKey() ).build();
+				storage.create( blobInfo, bytes );
+
+				super.close();
+				closed = true;
+			}
+		}
+	}
+
+	private static final String googleCloudProtocol = "gs";
+
+	private final Storage storage;
+
+	public GoogleCloudDataProvider( final Storage storage )
+	{
+		this.storage = storage;
+	}
+
+	@Override
+	public DataProviderType getType()
+	{
+		return DataProviderType.GOOGLE_CLOUD;
+	}
+
+	@Override
+	public URI getUri( final String path ) throws URISyntaxException
+	{
+		final URI uri = new URI( path );
+		if ( googleCloudProtocol.equals( uri.getScheme() ) )
+			return uri;
+		return new URI( googleCloudProtocol, null, path );
+	}
+
+	@Override
+	public boolean fileExists( final URI uri ) throws IOException
+	{
+		final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+		final Blob blob = storage.get( BlobId.of( googleCloudUri.getBucket(), googleCloudUri.getKey() ) );
+		return blob != null && blob.exists();
+	}
+
+	@Override
+	public void copyFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		final GoogleCloudStorageURI googleCloudUriSrc = new GoogleCloudStorageURI( uriSrc );
+		final GoogleCloudStorageURI googleCloudUriDst = new GoogleCloudStorageURI( uriDst );
+		final CopyRequest request = CopyRequest.newBuilder()
+				.setSource( BlobId.of( googleCloudUriSrc.getBucket(), googleCloudUriSrc.getKey() ) )
+				.setTarget( BlobId.of( googleCloudUriDst.getBucket(), googleCloudUriDst.getKey() ) )
+				.build();
+		storage.copy( request ).getResult();
+	}
+
+	@Override
+	public void moveFile( final URI uriSrc, final URI uriDst ) throws IOException
+	{
+		copyFile( uriSrc, uriDst );
+		deleteFile( uriSrc );
+	}
+
+	@Override
+	public void deleteFile( final URI uri ) throws IOException
+	{
+		final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+		storage.delete( BlobId.of( googleCloudUri.getBucket(), googleCloudUri.getKey() ) );
+	}
+
+	@Override
+	public void deleteFolder( final URI uri ) throws IOException
+	{
+		final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+		final String prefix = googleCloudUri.getKey().endsWith( "/" ) ? googleCloudUri.getKey() : googleCloudUri.getKey() + "/";
+		final List< BlobId > subBlobs = new ArrayList<>();
+		final Page< Blob > blobListing = storage.list( googleCloudUri.getBucket(), BlobListOption.prefix( prefix ) );
+		for ( final Iterator< Blob > blobIterator = blobListing.iterateAll().iterator(); blobIterator.hasNext(); )
+			subBlobs.add( blobIterator.next().getBlobId() );
+		storage.delete( subBlobs );
+	}
+
+	@Override
+	public InputStream getInputStream( final URI uri ) throws IOException
+	{
+		final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+		final Blob blob = storage.get( BlobId.of( googleCloudUri.getBucket(), googleCloudUri.getKey() ) );
+		final byte[] bytes = blob.getContent();
+		return new ByteArrayInputStream( bytes );
+	}
+
+	@Override
+	public OutputStream getOutputStream( final URI uri ) throws IOException
+	{
+		return new BlobOutputStream( new GoogleCloudStorageURI( uri ) );
+	}
+
+	@Override
+	public ImagePlus loadImage( final URI uri ) throws IOException
+	{
+		final String uriStr = uri.toString();
+		if ( uriStr.endsWith( ".tif" ) || uriStr.endsWith( ".tiff" ) )
+			return ImageImporter.openImage( uriStr );
+		throw new NotImplementedException( "Only TIFF images are supported at the moment" );
+	}
+
+	@Override
+	public void saveImage( final ImagePlus imp, final URI uri ) throws IOException
+	{
+		Utils.workaroundImagePlusNSlices( imp );
+		// Need to save as a local TIFF file and then upload to Google Cloud. IJ does not provide a way to convert ImagePlus to TIFF byte array.
+		Path tempPath = null;
+		try
+		{
+			tempPath = Files.createTempFile( null, ".tif" );
+			IJ.saveAsTiff( imp, tempPath.toString() );
+
+			final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+			final BlobInfo blobInfo = BlobInfo.newBuilder( googleCloudUri.getBucket(), googleCloudUri.getKey() ).build();
+			final byte[] bytes = Files.readAllBytes( tempPath );
+			storage.create( blobInfo, bytes );
+		}
+		finally
+		{
+			if ( tempPath != null )
+				tempPath.toFile().delete();
+		}
+	}
+
+	@Override
+	public Reader getJsonReader( final URI uri ) throws IOException
+	{
+		return new InputStreamReader( getInputStream( uri ) );
+	}
+
+	@Override
+	public Writer getJsonWriter( final URI uri ) throws IOException
+	{
+		return new OutputStreamWriter( getOutputStream( uri ) );
+	}
+
+	@Override
+	public N5Reader createN5Reader( final URI baseUri ) throws IOException
+	{
+		return N5GoogleCloudStorage.openCloudStorageReader( storage, new GoogleCloudStorageURI( baseUri ).getBucket() );
+	}
+
+	@Override
+	public N5Writer createN5Writer( final URI baseUri ) throws IOException
+	{
+		return N5GoogleCloudStorage.openCloudStorageWriter( storage, new GoogleCloudStorageURI( baseUri ).getBucket() );
+	}
+
+	@Override
+	public N5Reader createN5Reader( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
+	{
+		return N5GoogleCloudStorage.openCloudStorageReader( storage, new GoogleCloudStorageURI( baseUri ).getBucket(), gsonBuilder );
+	}
+
+	@Override
+	public N5Writer createN5Writer( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
+	{
+		return N5GoogleCloudStorage.openCloudStorageWriter( storage, new GoogleCloudStorageURI( baseUri ).getBucket(), gsonBuilder );
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/GoogleCloudDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/GoogleCloudDataProvider.java
@@ -85,7 +85,7 @@ class GoogleCloudDataProvider implements DataProvider
 	public URI getUri( final String path ) throws URISyntaxException
 	{
 		final URI uri = new URI( path );
-		if ( googleCloudProtocol.equals( uri.getScheme() ) )
+		if ( googleCloudProtocol.equalsIgnoreCase( uri.getScheme() ) )
 			return uri;
 		return new URI( googleCloudProtocol, null, path );
 	}

--- a/src/main/java/org/janelia/dataaccess/GoogleCloudStorageURLConnection.java
+++ b/src/main/java/org/janelia/dataaccess/GoogleCloudStorageURLConnection.java
@@ -1,0 +1,58 @@
+package org.janelia.dataaccess;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+
+class GoogleCloudStorageURLConnection extends URLConnection
+{
+	private final Storage storage;
+	private Blob blob;
+
+	public GoogleCloudStorageURLConnection( final Storage storage, final URL url )
+	{
+		super( url );
+		this.storage = storage;
+	}
+
+	@Override
+	public void connect() throws IOException
+	{
+		final URI uri;
+		try
+		{
+			uri = url.toURI();
+		}
+		catch ( final URISyntaxException e )
+		{
+			throw new RuntimeException( e );
+		}
+		final GoogleCloudStorageURI googleCloudUri = new GoogleCloudStorageURI( uri );
+		blob = storage.get( BlobId.of( googleCloudUri.getBucket(), googleCloudUri.getKey() ) );
+		connected = true;
+	}
+
+	@Override
+	public String getContentType()
+	{
+		return blob.getContentType();
+	}
+
+	@Override
+	public InputStream getInputStream() throws IOException
+	{
+		if ( !connected )
+			connect();
+		return new ByteArrayInputStream( blob.getContent() );
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/GoogleCloudStorageURLStreamHandler.java
+++ b/src/main/java/org/janelia/dataaccess/GoogleCloudStorageURLStreamHandler.java
@@ -1,0 +1,24 @@
+package org.janelia.dataaccess;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+
+import com.google.cloud.storage.Storage;
+
+class GoogleCloudStorageURLStreamHandler extends URLStreamHandler
+{
+	private final Storage storage;
+
+	public GoogleCloudStorageURLStreamHandler( final Storage storage )
+	{
+		this.storage = storage;
+	}
+
+	@Override
+	protected URLConnection openConnection( final URL url ) throws IOException
+	{
+		return new GoogleCloudStorageURLConnection( storage, url );
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/PathResolver.java
+++ b/src/main/java/org/janelia/dataaccess/PathResolver.java
@@ -1,0 +1,60 @@
+package org.janelia.dataaccess;
+
+import java.net.URI;
+import java.nio.file.Paths;
+
+public class PathResolver
+{
+	/**
+	 * Combines base and relative paths.
+	 * Supports links and local filesystem paths.
+	 *
+	 * @param base
+	 * @param rel
+	 * @return
+	 */
+	public static String get( final String basePath, final String... relativePaths )
+	{
+		// if a given path is a link, need to use URI functionality because Paths.get() in this case swallows the scheme
+		final URI baseUri = URI.create( basePath );
+		if ( baseUri.getScheme() != null )
+		{
+			URI combinedUri = baseUri;
+			for ( final String relativePath : relativePaths )
+			{
+				// base URI has to end with a slash, otherwise relative path replaces the last part of the base URI
+				if ( !combinedUri.toString().endsWith( "/" ) )
+					combinedUri = URI.create( combinedUri.toString() + "/" );
+
+				combinedUri = combinedUri.resolve( relativePath );
+			}
+			return combinedUri.toString();
+		}
+		else
+		{
+			return Paths.get( basePath, relativePaths ).toString();
+		}
+	}
+
+	public static String getParent( final String path )
+	{
+		// if a given path is a link, need to use URI functionality because Paths.get() in this case swallows the scheme
+		final URI uri = URI.create( path );
+		if ( uri.getScheme() != null )
+		{
+			// based on https://stackoverflow.com/a/10159309
+			final URI parentUri = uri.getPath().endsWith( "/" ) ? uri.resolve( ".." ) : uri.resolve( "." );
+			return parentUri.toString();
+		}
+		else
+		{
+			return Paths.get( path ).getParent().toString();
+		}
+	}
+
+	public static String getFileName( final String path )
+	{
+		// no need to preserve scheme, Paths.get() works in this case
+		return Paths.get( path ).getFileName().toString();
+	}
+}

--- a/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudDataProvider.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.googlecloud;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -18,6 +18,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderType;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageURI;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -37,7 +39,7 @@ import com.google.gson.GsonBuilder;
 import ij.IJ;
 import ij.ImagePlus;
 
-class GoogleCloudDataProvider implements DataProvider
+public class GoogleCloudDataProvider implements DataProvider
 {
 	private class BlobOutputStream extends ByteArrayOutputStream
 	{

--- a/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudDataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudDataProvider.java
@@ -200,24 +200,32 @@ public class GoogleCloudDataProvider implements DataProvider
 	@Override
 	public N5Reader createN5Reader( final URI baseUri ) throws IOException
 	{
-		return N5GoogleCloudStorage.openCloudStorageReader( storage, new GoogleCloudStorageURI( baseUri ).getBucket() );
+		return N5GoogleCloudStorage.openCloudStorageReader( storage, getBucketName( baseUri ) );
 	}
 
 	@Override
 	public N5Writer createN5Writer( final URI baseUri ) throws IOException
 	{
-		return N5GoogleCloudStorage.openCloudStorageWriter( storage, new GoogleCloudStorageURI( baseUri ).getBucket() );
+		return N5GoogleCloudStorage.openCloudStorageWriter( storage, getBucketName( baseUri ) );
 	}
 
 	@Override
 	public N5Reader createN5Reader( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
 	{
-		return N5GoogleCloudStorage.openCloudStorageReader( storage, new GoogleCloudStorageURI( baseUri ).getBucket(), gsonBuilder );
+		return N5GoogleCloudStorage.openCloudStorageReader( storage, getBucketName( baseUri ), gsonBuilder );
 	}
 
 	@Override
 	public N5Writer createN5Writer( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
 	{
-		return N5GoogleCloudStorage.openCloudStorageWriter( storage, new GoogleCloudStorageURI( baseUri ).getBucket(), gsonBuilder );
+		return N5GoogleCloudStorage.openCloudStorageWriter( storage, getBucketName( baseUri ), gsonBuilder );
+	}
+
+	private String getBucketName( final URI baseUri )
+	{
+		final GoogleCloudStorageURI uri = new GoogleCloudStorageURI( baseUri );
+		if ( uri.getKey() != null && !uri.getKey().isEmpty() )
+			throw new IllegalArgumentException( "baseUri should be a link to a bucket" );
+		return uri.getBucket();
 	}
 }

--- a/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudStorageURLConnection.java
+++ b/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudStorageURLConnection.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.googlecloud;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudStorageURLStreamHandler.java
+++ b/src/main/java/org/janelia/dataaccess/googlecloud/GoogleCloudStorageURLStreamHandler.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.googlecloud;
 
 import java.io.IOException;
 import java.net.URL;
@@ -7,7 +7,7 @@ import java.net.URLStreamHandler;
 
 import com.google.cloud.storage.Storage;
 
-class GoogleCloudStorageURLStreamHandler extends URLStreamHandler
+public class GoogleCloudStorageURLStreamHandler extends URLStreamHandler
 {
 	private final Storage storage;
 

--- a/src/main/java/org/janelia/dataaccess/s3/AmazonS3DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/s3/AmazonS3DataProvider.java
@@ -232,29 +232,37 @@ public class AmazonS3DataProvider implements DataProvider
 	@Override
 	public N5Reader createN5Reader( final URI baseUri ) throws IOException
 	{
-		return N5AmazonS3.openS3Reader( s3, decodeS3Uri( baseUri ).getBucket() );
+		return N5AmazonS3.openS3Reader( s3, getBucketName( baseUri ) );
 	}
 
 	@Override
 	public N5Writer createN5Writer( final URI baseUri ) throws IOException
 	{
-		return N5AmazonS3.openS3Writer( s3, decodeS3Uri( baseUri ).getBucket() );
+		return N5AmazonS3.openS3Writer( s3, getBucketName( baseUri ) );
 	}
 
 	@Override
 	public N5Reader createN5Reader( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
 	{
-		return N5AmazonS3.openS3Reader( s3, decodeS3Uri( baseUri ).getBucket(), gsonBuilder );
+		return N5AmazonS3.openS3Reader( s3, getBucketName( baseUri ), gsonBuilder );
 	}
 
 	@Override
 	public N5Writer createN5Writer( final URI baseUri, final GsonBuilder gsonBuilder ) throws IOException
 	{
-		return N5AmazonS3.openS3Writer( s3, decodeS3Uri( baseUri ).getBucket(), gsonBuilder );
+		return N5AmazonS3.openS3Writer( s3, getBucketName( baseUri ), gsonBuilder );
 	}
 
 	public static AmazonS3URI decodeS3Uri( final URI uri ) throws IOException
 	{
 		return new AmazonS3URI( URLDecoder.decode( uri.toString(), StandardCharsets.UTF_8.name() ) );
+	}
+
+	private String getBucketName( final URI baseUri ) throws IOException
+	{
+		final AmazonS3URI uri = decodeS3Uri( baseUri );
+		if ( uri.getKey() != null && !uri.getKey().isEmpty() )
+			throw new IllegalArgumentException( "baseUri should be a link to a bucket" );
+		return uri.getBucket();
 	}
 }

--- a/src/main/java/org/janelia/dataaccess/s3/AmazonS3DataProvider.java
+++ b/src/main/java/org/janelia/dataaccess/s3/AmazonS3DataProvider.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.s3;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.NotImplementedException;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderType;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.s3.N5AmazonS3;
@@ -45,7 +47,7 @@ import ij.ImagePlus;
  *
  * @author Igor Pisarev
  */
-class AmazonS3DataProvider implements DataProvider
+public class AmazonS3DataProvider implements DataProvider
 {
 	private class S3ObjectOutputStream extends ByteArrayOutputStream
 	{

--- a/src/main/java/org/janelia/dataaccess/s3/S3URLConnection.java
+++ b/src/main/java/org/janelia/dataaccess/s3/S3URLConnection.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.s3;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/janelia/dataaccess/s3/S3URLStreamHandler.java
+++ b/src/main/java/org/janelia/dataaccess/s3/S3URLStreamHandler.java
@@ -1,4 +1,4 @@
-package org.janelia.dataaccess;
+package org.janelia.dataaccess.s3;
 
 import java.io.IOException;
 import java.net.URL;
@@ -7,7 +7,7 @@ import java.net.URLStreamHandler;
 
 import com.amazonaws.services.s3.AmazonS3;
 
-class S3URLStreamHandler extends URLStreamHandler
+public class S3URLStreamHandler extends URLStreamHandler
 {
 	private final AmazonS3 s3;
 

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
@@ -86,16 +86,24 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 	}
 
 
-	public static < U extends NativeType< U > & RealType< U > > RandomAccessiblePairNullable< U, U > loadCorrectionImages( final String sPath, final String tPath, final int dimensionality )
+	public static < U extends NativeType< U > & RealType< U > > RandomAccessiblePairNullable< U, U > loadCorrectionImages(
+			final DataProvider dataProvider,
+			final String sPath,
+			final String tPath,
+			final int dimensionality ) throws IOException
 	{
 		System.out.println( "Loading flat-field components:" );
 		System.out.println( "  " + sPath );
 		System.out.println( "  " + tPath );
 
-		final ImagePlus sImp = ImageImporter.openImage( sPath );
-		final ImagePlus tImp = ImageImporter.openImage( tPath );
-		if ( sImp == null || tImp == null )
+		if ( !dataProvider.fileExists( URI.create( sPath ) ) || !dataProvider.fileExists( URI.create( tPath ) ) )
+		{
+			System.out.println( "  -- Flat-field images do not exist" );
 			return null;
+		}
+
+		final ImagePlus sImp = dataProvider.loadImage( URI.create( sPath ) );
+		final ImagePlus tImp = dataProvider.loadImage( URI.create( tPath ) );
 
 		final RandomAccessibleInterval< U > sImg = ImagePlusImgs.from( sImp );
 		final RandomAccessibleInterval< U > tImg = ImagePlusImgs.from( tImp );

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
@@ -142,7 +142,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 
 		tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args.inputFilePath() ) ) );
 		fullTileSize = getMinTileSize( tiles );
-		workingInterval = args.cropMinMaxInterval( fullTileSize );
+		workingInterval = args.cropMinMaxInterval( args.use2D() ? new long[] { fullTileSize[ 0 ], fullTileSize[ 1 ] } : fullTileSize );
 
 		System.out.println( "Working interval is at " + Arrays.toString( Intervals.minAsLongArray( workingInterval ) ) + " of size " + Arrays.toString( Intervals.dimensionsAsLongArray( workingInterval ) ) );
 
@@ -254,6 +254,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 //			return;
 //		}
 
+		System.out.println( "Running flatfield correction script in " + ( args.use2D() ? "2D" : "3D" ) + " mode" );
 
 		// FIXME: unify treemap and array histogram collectors
 //		final HistogramsProvider histogramsProvider = new HistogramsProvider(
@@ -265,7 +266,9 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 				histogramsPath,
 				tiles,
 				fullTileSize,
-				args.histMinValue(), args.histMaxValue(), args.bins() );
+				args.use2D(),
+				args.histMinValue(), args.histMaxValue(), args.bins()
+			);
 //		if ( exit )
 //		{
 //			System.out.println( "Done" );

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
@@ -65,7 +65,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 	private static final int SCALE_LEVEL_MIN_PIXELS = 1;
 	private static final int AVERAGE_SKIP_SLICES = 5;
 
-	private final String basePath, histogramsPath, solutionPath;
+	private final String basePath, solutionPath;
 
 	private transient final JavaSparkContext sparkContext;
 	private transient final TileInfo[] tiles;
@@ -154,9 +154,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 		System.out.println( "Working interval is at " + Arrays.toString( Intervals.minAsLongArray( workingInterval ) ) + " of size " + Arrays.toString( Intervals.dimensionsAsLongArray( workingInterval ) ) );
 
 		basePath = args.inputFilePath().substring( 0, args.inputFilePath().lastIndexOf( "." ) ) + flatfieldFolderSuffix;
-		final String outputPath = PathResolver.get( basePath, args.cropMinMaxIntervalStr() == null ? "fullsize" : args.cropMinMaxIntervalStr() );
-		histogramsPath = PathResolver.get( basePath, "histograms" );
-		solutionPath = PathResolver.get( outputPath, "solution" );
+		solutionPath = PathResolver.get( basePath, args.cropMinMaxIntervalStr() == null ? "fullsize" : args.cropMinMaxIntervalStr(), "solution" );
 
 		// check if all tiles have the same size
 		for ( final TileInfo tile : tiles )
@@ -247,7 +245,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 				sparkContext,
 				dataProvider,
 				workingInterval,
-				histogramsPath,
+				basePath,
 				tiles,
 				fullTileSize,
 				args.use2D(),

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
@@ -146,7 +146,7 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 
 		System.out.println( "Working interval is at " + Arrays.toString( Intervals.minAsLongArray( workingInterval ) ) + " of size " + Arrays.toString( Intervals.dimensionsAsLongArray( workingInterval ) ) );
 
-		basePath = args.inputFilePath().substring( 0, args.inputFilePath().lastIndexOf( "." ) ) + "-flatfield";
+		basePath = args.inputFilePath().substring( 0, args.inputFilePath().lastIndexOf( "." ) );
 		final String outputPath = Paths.get( basePath, args.cropMinMaxIntervalStr() == null ? "fullsize" : args.cropMinMaxIntervalStr() ).toString();
 		histogramsPath = Paths.get( basePath, "histograms" ).toString();
 		solutionPath = Paths.get( outputPath, "solution" ).toString();

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrectionArguments.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrectionArguments.java
@@ -39,6 +39,10 @@ public class FlatfieldCorrectionArguments
 			usage = "Max value of a histogram")
 	private double histMaxValue = 500;
 
+	@Option(name = "--2d", required = false,
+			usage = "Estimate 2D flatfield (slices are used as additional data points)")
+	private boolean use2D = false;
+
 
 	private boolean parsedSuccessfully = false;
 
@@ -65,6 +69,7 @@ public class FlatfieldCorrectionArguments
 	public Double histMinValue() { return histMinValue; }
 	public Double histMaxValue() { return histMaxValue; }
 	public String cropMinMaxIntervalStr() { return cropMinMaxInterval; };
+	public boolean use2D() { return use2D; }
 
 	public Interval cropMinMaxInterval( final long[] fullTileSize )
 	{

--- a/src/main/java/org/janelia/flatfield/HistogramsProvider.java
+++ b/src/main/java/org/janelia/flatfield/HistogramsProvider.java
@@ -21,6 +21,8 @@ import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
 import org.janelia.histogram.Histogram;
+import org.janelia.saalfeldlab.n5.CompressionType;
+import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.stitching.PipelineExecutionException;
 import org.janelia.stitching.TileInfo;
@@ -125,6 +127,14 @@ public class HistogramsProvider implements Serializable
 			cellGrid.getCellGridPositionFlat( index, blockGridPosition );
 			blockGridPositions.add( blockGridPosition );
 		}
+
+		dataProvider.createN5Writer( URI.create( histogramsPath ) ).createDataset(
+				channelDatasetPath,
+				fullTileSize,
+				blockSize,
+				DataType.SERIALIZABLE,
+				CompressionType.GZIP
+			);
 
 		sparkContext.parallelize( blockGridPositions ).foreach( blockGridPosition ->
 			{

--- a/src/main/java/org/janelia/flatfield/HistogramsProvider.java
+++ b/src/main/java/org/janelia/flatfield/HistogramsProvider.java
@@ -215,10 +215,21 @@ public class HistogramsProvider implements Serializable
 				for ( final TileInfo tile : tiles )
 				{
 					final RandomAccessibleInterval< T > tileImg = TileLoader.loadTile( tile, dataProviderLocal );
-					final Interval tileImgOffsetInterval = new FinalInterval(
-							new long[] { blockInterval.min( 0 ), blockInterval.min( 1 ), blockInterval.numDimensions() >= 3 ? blockInterval.min( 2 ) : tileImg.min( 2 ) },
-							new long[] { blockInterval.max( 0 ), blockInterval.max( 1 ), blockInterval.numDimensions() >= 3 ? blockInterval.max( 2 ) : tileImg.max( 2 ) }
-						);
+					final Interval tileImgOffsetInterval;
+					if ( tileImg.numDimensions() == 3 )
+					{
+						tileImgOffsetInterval = new FinalInterval(
+								new long[] { blockInterval.min( 0 ), blockInterval.min( 1 ), blockInterval.numDimensions() >= 3 ? blockInterval.min( 2 ) : tileImg.min( 2 ) },
+								new long[] { blockInterval.max( 0 ), blockInterval.max( 1 ), blockInterval.numDimensions() >= 3 ? blockInterval.max( 2 ) : tileImg.max( 2 ) }
+							);
+					}
+					else
+					{
+						tileImgOffsetInterval = new FinalInterval(
+								new long[] { blockInterval.min( 0 ), blockInterval.min( 1 ) },
+								new long[] { blockInterval.max( 0 ), blockInterval.max( 1 ) }
+							);
+					}
 					final RandomAccessibleInterval< T > tileImgInterval = Views.offsetInterval( tileImg, tileImgOffsetInterval );
 					final IterableInterval< T > tileImgIterableInterval = Views.iterable( tileImgInterval );
 					final Cursor< T > tileImgIntervalCursor = tileImgIterableInterval.localizingCursor();

--- a/src/main/java/org/janelia/flatfield/HistogramsProvider.java
+++ b/src/main/java/org/janelia/flatfield/HistogramsProvider.java
@@ -425,6 +425,11 @@ public class HistogramsProvider implements Serializable
 
 	private boolean allHistogramsReady() throws IOException, URISyntaxException
 	{
+		// check if histograms exist in newer block-based format
+		if ( dataProvider.createN5Reader( URI.create( histogramsN5BasePath ) ).datasetExists( HISTOGRAMS_N5_DATASET_NAME ) )
+			return true;
+
+		// check if histograms exist in old slice-based format
 		for ( int slice = 1; slice <= getNumSlices(); slice++ )
 			if ( !dataProvider.fileExists( dataProvider.getUri( generateSliceHistogramsPath( 0, slice ) ) ) )
 				return false;

--- a/src/main/java/org/janelia/flatfield/HistogramsProvider.java
+++ b/src/main/java/org/janelia/flatfield/HistogramsProvider.java
@@ -143,7 +143,7 @@ public class HistogramsProvider implements Serializable
 				CompressionType.GZIP
 			);
 
-		sparkContext.parallelize( blockGridPositions ).foreach( blockGridPosition ->
+		sparkContext.parallelize( blockGridPositions, blockGridPositions.size() ).foreach( blockGridPosition ->
 			{
 				final DataProvider dataProviderLocal = DataProviderFactory.createByType( dataProviderType );
 				final N5Writer n5Local = dataProviderLocal.createN5Writer( URI.create( histogramsPath ) );
@@ -255,7 +255,7 @@ public class HistogramsProvider implements Serializable
 			blockGridPositions.add( blockGridPosition );
 		}
 
-		rddHistograms = sparkContext.parallelize( blockGridPositions ) .flatMapToPair( blockGridPosition ->
+		rddHistograms = sparkContext.parallelize( blockGridPositions, blockGridPositions.size() ) .flatMapToPair( blockGridPosition ->
 					{
 						final DataProvider dataProviderLocal = DataProviderFactory.createByType( dataProviderType );
 						final N5Writer n5Local = dataProviderLocal.createN5Writer( URI.create( histogramsPath ) );
@@ -323,7 +323,7 @@ public class HistogramsProvider implements Serializable
 				);
 		}
 
-		sparkContext.parallelize( blockGridPositions ).foreach( blockGridPosition ->
+		sparkContext.parallelize( blockGridPositions, blockGridPositions.size() ).foreach( blockGridPosition ->
 			{
 				final DataProvider dataProviderLocal = DataProviderFactory.createByType( dataProviderType );
 				final N5Writer n5Local = dataProviderLocal.createN5Writer( URI.create( histogramsN5BasePath ) );

--- a/src/main/java/org/janelia/flatfield/HistogramsProvider.java
+++ b/src/main/java/org/janelia/flatfield/HistogramsProvider.java
@@ -141,13 +141,17 @@ public class HistogramsProvider implements Serializable
 			blockGridPositions.add( blockGridPosition );
 		}
 
-		dataProvider.createN5Writer( URI.create( histogramsN5BasePath ) ).createDataset(
-				HISTOGRAMS_N5_DATASET_NAME,
-				fullTileSize,
-				blockSize,
-				DataType.SERIALIZABLE,
-				CompressionType.GZIP
-			);
+		final N5Writer n5 = dataProvider.createN5Writer( URI.create( histogramsN5BasePath ) );
+		if ( !n5.datasetExists( HISTOGRAMS_N5_DATASET_NAME ) )
+		{
+			n5.createDataset(
+					HISTOGRAMS_N5_DATASET_NAME,
+					fullTileSize,
+					blockSize,
+					DataType.SERIALIZABLE,
+					CompressionType.GZIP
+				);
+		}
 
 		sparkContext.parallelize( blockGridPositions, blockGridPositions.size() ).foreach( blockGridPosition ->
 			{

--- a/src/main/java/org/janelia/flatfield/SerializableDataBlockWrapper.java
+++ b/src/main/java/org/janelia/flatfield/SerializableDataBlockWrapper.java
@@ -32,7 +32,11 @@ public class SerializableDataBlockWrapper< T extends Serializable >
 		}
 		else
 		{
-			dataBlock = datasetAttributes.getDataType().createDataBlock( datasetAttributes.getBlockSize(), gridPosition );
+			// compute the block size accounting for the border blocks that can be smaller than regular blocks
+			final int[] blockSize = new int[ datasetAttributes.getNumDimensions() ];
+			for ( int d = 0; d < blockSize.length; ++d )
+				blockSize[ d ] = ( int ) Math.min( datasetAttributes.getDimensions()[ d ] - gridPosition[ d ] * datasetAttributes.getBlockSize()[ d ], datasetAttributes.getBlockSize()[ d ] );
+			dataBlock = datasetAttributes.getDataType().createDataBlock( blockSize, gridPosition );
 		}
 	}
 

--- a/src/main/java/org/janelia/flatfield/SerializableDataBlockWrapper.java
+++ b/src/main/java/org/janelia/flatfield/SerializableDataBlockWrapper.java
@@ -1,0 +1,54 @@
+package org.janelia.flatfield;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import org.janelia.saalfeldlab.n5.DataBlock;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.N5Writer;
+
+import net.imglib2.FinalDimensions;
+import net.imglib2.img.list.WrappedListImg;
+import net.imglib2.util.Intervals;
+
+public class SerializableDataBlockWrapper< T extends Serializable >
+{
+	private final N5Writer n5;
+	private final String pathName;
+	private final DataBlock< ? > dataBlock;
+
+	public SerializableDataBlockWrapper( final N5Writer n5, final String pathName, final long[] gridPosition ) throws IOException
+	{
+		this.n5 = n5;
+		this.pathName = pathName;
+
+		final DatasetAttributes datasetAttributes = n5.getDatasetAttributes( pathName );
+		final DataBlock< ? > loadedDataBlock = n5.readBlock( pathName, datasetAttributes, gridPosition );
+		if ( loadedDataBlock != null )
+		{
+			dataBlock = loadedDataBlock;
+		}
+		else
+		{
+			dataBlock = datasetAttributes.getDataType().createDataBlock( datasetAttributes.getBlockSize(), gridPosition );
+		}
+	}
+
+	public WrappedListImg< T > wrap()
+	{
+		@SuppressWarnings( "unchecked" )
+		final T[] data = ( T[] ) dataBlock.getData();
+		final List< T > dataAsList = Arrays.asList( data );
+		final long[] blockDimensions = Intervals.dimensionsAsLongArray( new FinalDimensions( dataBlock.getSize() ) );
+		final WrappedListImg< T > listImg = new WrappedListImg<>( dataAsList, blockDimensions );
+		return listImg;
+	}
+
+	public void save() throws IOException
+	{
+		final DatasetAttributes datasetAttributes = n5.getDatasetAttributes( pathName );
+		n5.writeBlock( pathName, datasetAttributes, dataBlock );
+	}
+}

--- a/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
@@ -1,12 +1,17 @@
 package org.janelia.stitching;
 
+import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
-import org.janelia.saalfeldlab.n5.N5;
-import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderFactory;
+import org.janelia.dataaccess.DataProviderType;
+import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
 import org.janelia.saalfeldlab.n5.spark.N5MaxIntensityProjection;
 import org.janelia.saalfeldlab.n5.spark.TiffUtils;
@@ -65,22 +70,30 @@ public class N5ToMIPsSpark
 		final String outputPath = Paths.get( outBaseFolder, outFolder ).toString();
 		System.out.println( "Output path: " + outputPath );
 
+		final DataProvider dataProvider = DataProviderFactory.createByURI( URI.create( n5Path ) );
+		final DataProviderType dataProviderType = dataProvider.getType();
+
+		final List< int[] > channelsCellDimensions = new ArrayList<>();
+		final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ) );
+		final N5ExportMetadata exportMetadata = new N5ExportMetadata( n5Path );
+		for ( int channel = 0; channel < exportMetadata.getNumChannels(); ++channel )
+		{
+			final String n5DatasetPath = N5ExportMetadata.getScaleLevelDatasetPath( channel, scaleLevel );
+			final int[] cellDimensions = n5.getDatasetAttributes( n5DatasetPath ).getBlockSize();
+			channelsCellDimensions.add( cellDimensions );
+		}
+
 		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
 				.setAppName( "N5ToMIPs" )
 				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
 				.set( "spark.rdd.compress", "true" )
 			) )
 		{
-			final N5ExportMetadata exportMetadata = new N5ExportMetadata( n5Path );
-			for ( int channel = 0; channel < exportMetadata.getNumChannels(); ++channel )
+			for ( int channel = 0; channel < channelsCellDimensions.size(); ++channel )
 			{
 				final String n5DatasetPath = N5ExportMetadata.getScaleLevelDatasetPath( channel, scaleLevel );
 				final String outputChannelPath = Paths.get( outputPath, "ch" + channel ).toString();
-
-				final N5Writer n5 = N5.openFSWriter( n5Path );
-				final DatasetAttributes attributes = n5.getDatasetAttributes( n5DatasetPath );
-				final int[] cellDimensions = attributes.getBlockSize();
-
+				final int[] cellDimensions = channelsCellDimensions.get( channel );
 				final int[] mipStepsCells = new int[ cellDimensions.length ];
 				for ( int d = 0; d < mipStepsCells.length; ++d )
 				{
@@ -97,7 +110,13 @@ public class N5ToMIPsSpark
 
 				N5MaxIntensityProjection.createMaxIntensityProjection(
 						sparkContext,
-						n5,
+						() -> {
+							try {
+								return DataProviderFactory.createByType( dataProviderType ).createN5Reader( URI.create( n5Path ) );
+							} catch ( final IOException e ) {
+								throw new RuntimeException( e );
+							}
+						},
 						n5DatasetPath,
 						mipStepsCells,
 						outputChannelPath,

--- a/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
@@ -2,7 +2,6 @@ package org.janelia.stitching;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,6 +10,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
+import org.janelia.dataaccess.PathResolver;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataReader;
@@ -64,11 +64,11 @@ public class N5ToMIPsSpark
 		final int scaleLevel = binned ? SCALE_LEVEL_BINNED : SCALE_LEVEL;
 		System.out.println( "Using scale level " + scaleLevel + " to generate MIPs" );
 
-		final String outBaseFolder = Paths.get( n5Path ).getParent().toString();
+		final String outBaseFolder = PathResolver.getParent( n5Path );
 		final String slicingSuffix = ( slicing != null ? "-" + arrayToString( slicing ) : "" );
 		final String binnedSuffix = ( binned ? "-binned" : "" );
 		final String outFolder = "MIP" + slicingSuffix + binnedSuffix;
-		final String outputPath = Paths.get( outBaseFolder, outFolder ).toString();
+		final String outputPath = PathResolver.get( outBaseFolder, outFolder );
 		System.out.println( "Output path: " + outputPath );
 
 		final DataProvider dataProvider = DataProviderFactory.createByURI( URI.create( n5Path ) );
@@ -93,7 +93,7 @@ public class N5ToMIPsSpark
 			for ( int channel = 0; channel < channelsCellDimensions.size(); ++channel )
 			{
 				final String n5DatasetPath = N5ExportMetadata.getScaleLevelDatasetPath( channel, scaleLevel );
-				final String outputChannelPath = Paths.get( outputPath, "ch" + channel ).toString();
+				final String outputChannelPath = PathResolver.get( outputPath, "ch" + channel );
 				final int[] cellDimensions = channelsCellDimensions.get( channel );
 				final int[] mipStepsCells = new int[ cellDimensions.length ];
 				for ( int d = 0; d < mipStepsCells.length; ++d )

--- a/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToMIPsSpark.java
@@ -13,6 +13,7 @@ import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
+import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataReader;
 import org.janelia.saalfeldlab.n5.spark.N5MaxIntensityProjection;
 import org.janelia.saalfeldlab.n5.spark.TiffUtils;
 
@@ -74,8 +75,8 @@ public class N5ToMIPsSpark
 		final DataProviderType dataProviderType = dataProvider.getType();
 
 		final List< int[] > channelsCellDimensions = new ArrayList<>();
-		final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ) );
-		final N5ExportMetadata exportMetadata = new N5ExportMetadata( n5Path );
+		final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ), N5ExportMetadata.getGsonBuilder() );
+		final N5ExportMetadataReader exportMetadata = N5ExportMetadata.openForReading( n5 );
 		for ( int channel = 0; channel < exportMetadata.getNumChannels(); ++channel )
 		{
 			final String n5DatasetPath = N5ExportMetadata.getScaleLevelDatasetPath( channel, scaleLevel );
@@ -112,7 +113,7 @@ public class N5ToMIPsSpark
 						sparkContext,
 						() -> {
 							try {
-								return DataProviderFactory.createByType( dataProviderType ).createN5Reader( URI.create( n5Path ) );
+								return DataProviderFactory.createByType( dataProviderType ).createN5Reader( URI.create( n5Path ), N5ExportMetadata.getGsonBuilder() );
 							} catch ( final IOException e ) {
 								throw new RuntimeException( e );
 							}

--- a/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
@@ -9,7 +9,9 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
+import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
+import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataReader;
 import org.janelia.saalfeldlab.n5.spark.N5SliceTiffConverter;
 import org.janelia.saalfeldlab.n5.spark.TiffUtils;
 
@@ -61,9 +63,11 @@ public class N5ToSliceTiffSpark
 		final DataProvider dataProvider = DataProviderFactory.createByURI( URI.create( n5Path ) );
 		final DataProviderType dataProviderType = dataProvider.getType();
 
+		final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ), N5ExportMetadata.getGsonBuilder() );
+
 		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf().setAppName( "ConvertN5ToSliceTIFF" ) ) )
 		{
-			final N5ExportMetadata exportMetadata = new N5ExportMetadata( n5Path );
+			final N5ExportMetadataReader exportMetadata = N5ExportMetadata.openForReading( n5 );
 			for ( int channel = 0; channel < exportMetadata.getNumChannels(); ++channel )
 			{
 				if ( requestedChannel != null && channel != requestedChannel.intValue() )
@@ -75,7 +79,7 @@ public class N5ToSliceTiffSpark
 						sparkContext,
 						() -> {
 							try {
-								return DataProviderFactory.createByType( dataProviderType ).createN5Reader( URI.create( n5Path ) );
+								return DataProviderFactory.createByType( dataProviderType ).createN5Reader( URI.create( n5Path ), N5ExportMetadata.getGsonBuilder() );
 							} catch ( final IOException e ) {
 								throw new RuntimeException( e );
 							}

--- a/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
@@ -2,13 +2,13 @@ package org.janelia.stitching;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
+import org.janelia.dataaccess.PathResolver;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataReader;
@@ -52,9 +52,9 @@ public class N5ToSliceTiffSpark
 		final int scaleLevel = binned ? SCALE_LEVEL_BINNED : SCALE_LEVEL;
 		System.out.println( "Using scale level " + scaleLevel + " to generate slice TIFFs" );
 
-		final String outBaseFolder = Paths.get( n5Path ).getParent().toString();
+		final String outBaseFolder = PathResolver.getParent( n5Path );
 		final String outFolder = "slice-tiff" + ( binned ? "-binned" : "" );
-		final String outputPath = Paths.get( outBaseFolder, outFolder ).toString();
+		final String outputPath = PathResolver.get( outBaseFolder, outFolder );
 		System.out.println( "Output path: " + outputPath );
 		System.out.println( "Tiff compression: none" );
 
@@ -74,7 +74,7 @@ public class N5ToSliceTiffSpark
 					continue;
 
 				final String n5DatasetPath = N5ExportMetadata.getScaleLevelDatasetPath( channel, scaleLevel );
-				final String outputChannelPath = Paths.get( outputPath, "ch" + channel ).toString();
+				final String outputChannelPath = PathResolver.get( outputPath, "ch" + channel );
 				N5SliceTiffConverter.convertToSliceTiff(
 						sparkContext,
 						() -> {

--- a/src/main/java/org/janelia/stitching/ParseTilesImageList.java
+++ b/src/main/java/org/janelia/stitching/ParseTilesImageList.java
@@ -2,6 +2,7 @@ package org.janelia.stitching;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,6 +12,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.stitching.analysis.CheckConnectedGraphs;
 import org.janelia.stitching.analysis.FilterAdjacentShifts;
 
@@ -138,7 +141,8 @@ public class ParseTilesImageList
 		System.out.println();
 
 		// finally save the configurations as JSON files
+		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 		for ( final int channel : tiles.keySet() )
-			TileInfoJSONProvider.saveTilesConfiguration( tiles.get( channel ).toArray( new TileInfo[ 0 ] ), Paths.get( baseOutputFolder, channel + "nm.json" ).toString() );
+			TileInfoJSONProvider.saveTilesConfiguration( tiles.get( channel ).toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Paths.get( baseOutputFolder, channel + "nm.json" ).toString() ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -18,7 +18,6 @@ import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
 import org.janelia.flatfield.FlatfieldCorrection;
 import org.janelia.saalfeldlab.n5.CompressionType;
-import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataWriter;
@@ -210,7 +209,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 				fullScaleOutputPath,
 				Intervals.dimensionsAsLongArray( boundingBox ),
 				cellSize,
-				getN5DataType( tiles[ 0 ].getType() ),
+				N5Utils.dataType( ( T ) tiles[ 0 ].getType().getType() ),
 				CompressionType.GZIP
 			);
 
@@ -241,21 +240,6 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 				N5Utils.saveBlock( outImg, n5Local, fullScaleOutputPath, biggerCellGridPosition );
 			}
 		);
-	}
-
-	private DataType getN5DataType( final ImageType imageType )
-	{
-		switch ( imageType )
-		{
-		case GRAY8:
-			return DataType.UINT8;
-		case GRAY16:
-			return DataType.UINT16;
-		case GRAY32:
-			return DataType.FLOAT32;
-		default:
-			return null;
-		}
 	}
 
 	private Map< Integer, Set< Integer > > getPairwiseConnectionsMap( final String channelPath ) throws PipelineExecutionException

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -21,6 +21,7 @@ import org.janelia.saalfeldlab.n5.CompressionType;
 import org.janelia.saalfeldlab.n5.DataType;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadata;
+import org.janelia.saalfeldlab.n5.bdv.N5ExportMetadataWriter;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.spark.N5DownsamplingSpark;
 import org.janelia.stitching.FusionPerformer.FusionMode;
@@ -104,7 +105,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 		final DataProviderType dataProviderType = dataProvider.getType();
 
 		final String n5ExportPath = baseExportPath;
-		final N5Writer n5 = dataProvider.createN5Writer( URI.create( n5ExportPath ) );
+		final N5Writer n5 = dataProvider.createN5Writer( URI.create( n5ExportPath ), N5ExportMetadata.getGsonBuilder() );
 
 		int[][] downsamplingFactors = null;
 
@@ -168,8 +169,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 		for ( int s = 0; s < downsamplingFactors.length; ++s )
 			scalesDouble[ s ] = Conversions.toDoubleArray( downsamplingFactors[ s ] );
 
-		// TODO: pass data provider
-		final N5ExportMetadata exportMetadata = new N5ExportMetadata( n5ExportPath );
+		final N5ExportMetadataWriter exportMetadata = N5ExportMetadata.openForWriting( n5 );
 		exportMetadata.setDefaultScales( scalesDouble );
 		exportMetadata.setDefaultPixelResolution( new FinalVoxelDimensions( "um", voxelDimensions ) );
 	}

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -2,7 +2,6 @@ package org.janelia.stitching;
 
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +15,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
+import org.janelia.dataaccess.PathResolver;
 import org.janelia.flatfield.FlatfieldCorrection;
 import org.janelia.saalfeldlab.n5.CompressionType;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -81,7 +81,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 		String baseExportPath = null;
 		for ( final String inputFilePath : job.getArgs().inputTileConfigurations() )
 		{
-			final String inputFolderPath = Paths.get( inputFilePath ).getParent().toString();
+			final String inputFolderPath = PathResolver.getParent( inputFilePath );
 			if ( baseExportPath == null )
 			{
 				baseExportPath = inputFolderPath;
@@ -89,12 +89,12 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 			else if ( !baseExportPath.equals( inputFolderPath ) )
 			{
 				// go one level upper since channels are stored in individual subfolders
-				baseExportPath = Paths.get( inputFolderPath ).getParent().toString();
+				baseExportPath = PathResolver.getParent( inputFolderPath );
 				break;
 			}
 		}
 
-		baseExportPath = Paths.get( baseExportPath, "export.n5" + overlapsPathSuffix ).toString();
+		baseExportPath = PathResolver.get( baseExportPath, "export.n5" + overlapsPathSuffix );
 
 		// FIXME: allow it for now
 //		if ( Files.exists( Paths.get( baseExportPath ) ) )
@@ -250,7 +250,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 		final Map< Integer, Set< Integer > > pairwiseConnectionsMap = new HashMap<>();
 		try
 		{
-			final String pairwiseShiftsPath = Paths.get( channelPath ).getParent().resolve( "pairwise-stitched.json" ).toString();
+			final String pairwiseShiftsPath = PathResolver.get( PathResolver.getParent( channelPath ), "pairwise-stitched.json" );
 			final List< SerializablePairWiseStitchingResult[] > pairwiseShifts = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( pairwiseShiftsPath ) ) );
 			for ( final SerializablePairWiseStitchingResult[] pairwiseShiftMulti : pairwiseShifts )
 			{

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -133,8 +133,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 			// use it as a folder with the input file's name
 			final RandomAccessiblePairNullable< U, U >  flatfieldCorrection = FlatfieldCorrection.loadCorrectionImages(
 					dataProvider,
-					absoluteChannelPathNoExt + "-flatfield/S.tif",
-					absoluteChannelPathNoExt + "-flatfield/T.tif",
+					absoluteChannelPathNoExt,
 					job.getDimensionality()
 				);
 			if ( flatfieldCorrection != null )

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -227,14 +227,15 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 				final CellGrid cellGrid = new CellGrid( dimensions, cellSize );
 				cellGrid.getCellPosition( biggerCellOffsetCoordinates, biggerCellGridPosition );
 
-				final ImagePlusImg< T, ? > outImg = FusionPerformer.fuseTilesWithinCell(
-							job.getArgs().blending() ? FusionMode.BLENDING : FusionMode.MAX_MIN_DISTANCE,
-							tilesWithinCell,
-							biggerCellBox,
-							broadcastedFlatfieldCorrection.value(),
-							broadcastedPairwiseConnectionsMap.value() );
-
 				final DataProvider dataProviderLocal = job.getDataProvider();
+				final ImagePlusImg< T, ? > outImg = FusionPerformer.fuseTilesWithinCell(
+						dataProviderLocal,
+						job.getArgs().blending() ? FusionMode.BLENDING : FusionMode.MAX_MIN_DISTANCE,
+						tilesWithinCell,
+						biggerCellBox,
+						broadcastedFlatfieldCorrection.value(),
+						broadcastedPairwiseConnectionsMap.value()
+					);
 				final N5Writer n5Local = dataProviderLocal.createN5Writer( URI.create( n5ExportPath ) );
 				N5Utils.saveBlock( outImg, n5Local, fullScaleOutputPath, biggerCellGridPosition );
 			}

--- a/src/main/java/org/janelia/stitching/PipelineIntensityCorrectionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineIntensityCorrectionStepExecutor.java
@@ -3,7 +3,6 @@ package org.janelia.stitching;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -15,6 +14,7 @@ import java.util.TreeMap;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.PathResolver;
 import org.janelia.histogram.Histogram;
 import org.janelia.histogram.HistogramMatching;
 import org.janelia.intensity.LinearIntensityMap;
@@ -247,7 +247,7 @@ public class PipelineIntensityCorrectionStepExecutor extends PipelineStepExecuto
 				final ImagePlusImg< T, ? > r = ImagePlusImgs.from( imp );
 				transform.run( r );
 
-				tile.setFilePath( destFolder + "/transformed_" + Paths.get( tile.getFilePath() ).getFileName().toString() );
+				tile.setFilePath( destFolder + "/transformed_" + PathResolver.getFileName( tile.getFilePath() ) );
 				final ImagePlus transformed = r.getImagePlus();
 				Utils.workaroundImagePlusNSlices( transformed );
 				dataProviderLocal.saveImage( transformed, URI.create( tile.getFilePath() ) );

--- a/src/main/java/org/janelia/stitching/PipelineMetadataStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineMetadataStepExecutor.java
@@ -220,7 +220,16 @@ public class PipelineMetadataStepExecutor extends PipelineStepExecutor
 			final String[] fileList = imagesBaseDir.list( fileNameChannelFilter );
 			for ( final String fileName : fileList )
 			{
-				final String coordinates = Utils.getTileCoordinatesString( fileName );
+				final String coordinates;
+				try
+				{
+					coordinates = Utils.getTileCoordinatesString( fileName );
+				}
+				catch ( final Exception e )
+				{
+					continue;
+				}
+
 				if ( !channelCoordinatesToTiles.get( channel ).containsKey( coordinates ) && coordinatesToPosition.containsKey( coordinates ) )
 				{
 					final TileInfo newTile = new TileInfo();

--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -219,24 +219,28 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 
 		// Try to load precalculated shifts for some pairs of tiles
 		final List< SerializablePairWiseStitchingResult[] > pairwiseShiftsMulti = new ArrayList<>();
-		try
+
+		if ( dataProvider.fileExists( URI.create( pairwisePath ) ) )
 		{
-			System.out.println( "try to load pairwise results from disk" );
-			pairwiseShiftsMulti.addAll( TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( pairwisePath ) ) ) );
-		}
-		catch ( final FileNotFoundException e )
-		{
-			System.out.println( "Pairwise results file not found" );
-		}
-		catch ( final NullPointerException e )
-		{
-			System.out.println( "Pairwise results file is malformed" );
-			e.printStackTrace();
-			throw e;
-		}
-		catch ( final IOException e )
-		{
-			e.printStackTrace();
+			try
+			{
+				System.out.println( "try to load pairwise results from disk" );
+				pairwiseShiftsMulti.addAll( TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( pairwisePath ) ) ) );
+			}
+			catch ( final FileNotFoundException e )
+			{
+				System.out.println( "Pairwise results file not found" );
+			}
+			catch ( final NullPointerException e )
+			{
+				System.out.println( "Pairwise results file is malformed" );
+				e.printStackTrace();
+				throw e;
+			}
+			catch ( final IOException e )
+			{
+				e.printStackTrace();
+			}
 		}
 
 		// remove redundant pairs (that are not contained in the given overlappingTiles list)

--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -378,15 +378,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 		for ( final String channelPath : job.getArgs().inputTileConfigurations() )
 		{
 			final String channelPathNoExt = channelPath.lastIndexOf( '.' ) != -1 ? channelPath.substring( 0, channelPath.lastIndexOf( '.' ) ) : channelPath;
-			// use it as a folder with the input file's name
-			flatfieldCorrectionForChannels.add(
-					FlatfieldCorrection.loadCorrectionImages(
-							dataProvider,
-							channelPathNoExt + "-flatfield/S.tif",
-							channelPathNoExt + "-flatfield/T.tif",
-							job.getDimensionality()
-						)
-				);
+			flatfieldCorrectionForChannels.add( FlatfieldCorrection.loadCorrectionImages( dataProvider, channelPathNoExt, job.getDimensionality() ) );
 		}
 		final Broadcast< List< RandomAccessiblePairNullable< U, U > > > broadcastedFlatfieldCorrectionForChannels = sparkContext.broadcast( flatfieldCorrectionForChannels );
 

--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -143,7 +143,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 					if ( stitchedTiles.length < previousStitchedTiles.length || ( stitchedTiles.length == previousStitchedTiles.length && usedPairs.size() <= previousUsedPairs.size() ) )
 					{
 						// mark the last solution as not used because it is worse than from the previous iteration
-						dataProvider.moveFile(
+						dataProvider.moveFolder(
 								URI.create( PathResolver.get( basePath, iterationDirname ) ),
 								URI.create( PathResolver.get( basePath, Utils.addFilenameSuffix( iterationDirname, "-notused" ) ) )
 							);

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -65,6 +65,10 @@ public class StitchingArguments implements Serializable {
 
 	private RestitchingMode restitchingMode = null;
 
+	@Option(name = "--noleaves", required = false,
+			usage = "Optimize tile configurations that don't contain any leaves (thus all edges are properly constrained)")
+	private boolean noLeaves = false;
+
 	@Option(name = "--overlaps", required = false,
 			usage = "Export overlaps channel based on which connections between tiles have been used for final stitching")
 	private boolean exportOverlaps = false;
@@ -136,6 +140,7 @@ public class StitchingArguments implements Serializable {
 	public int fusionCellSize() { return fusionCellSize; }
 	public double blurSigma() { return blurSigma; }
 	public boolean useAllPairs() { return allPairs; }
+	public boolean noLeaves() { return noLeaves; }
 	public boolean exportOverlaps() { return exportOverlaps; }
 	public boolean blending() { return blending; }
 

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -24,7 +24,7 @@ public class StitchingArguments implements Serializable {
 	private static final long serialVersionUID = -8996450783846140673L;
 
 	@Option(name = "-i", aliases = { "--input" }, required = true,
-			usage = "Path to a tile configuration JSON file. Multiple configurations can be passed at once.")
+			usage = "Path/link to a tile configuration JSON file. Multiple configurations can be passed at once.")
 	private List< String > inputTileConfigurations;
 
 	@Option(name = "-n", aliases = { "--neighbors" }, required = false,

--- a/src/main/java/org/janelia/stitching/StitchingSpark.java
+++ b/src/main/java/org/janelia/stitching/StitchingSpark.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,8 +47,10 @@ public class StitchingSpark implements Serializable, AutoCloseable
 		job = new StitchingJob( args );
 		try {
 			final List< TileInfo[] > tilesMultichannel = new ArrayList<>();
-			for ( int channel = 0; channel < job.getChannels(); channel++ )
-				tilesMultichannel.add( TileInfoJSONProvider.loadTilesConfiguration( args.inputTileConfigurations().get( channel ) ) );
+			for ( int channel = 0; channel < job.getChannels(); channel++ ) {
+				final URI tileConfigUri = URI.create( args.inputTileConfigurations().get( channel ) );
+				tilesMultichannel.add( TileInfoJSONProvider.loadTilesConfiguration( job.getDataProvider().getJsonReader( tileConfigUri ) ) );
+			}
 
 			job.setTilesMultichannel( tilesMultichannel );
 		} catch ( final Exception e ) {

--- a/src/main/java/org/janelia/stitching/TileLoader.java
+++ b/src/main/java/org/janelia/stitching/TileLoader.java
@@ -44,7 +44,7 @@ public class TileLoader
 
 	public static String getChannelN5DatasetPath( final TileInfo tile )
 	{
-		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String n5Path = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
 		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
 		return tileDatasetPath;
 	}

--- a/src/main/java/org/janelia/stitching/TileLoader.java
+++ b/src/main/java/org/janelia/stitching/TileLoader.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.PathResolver;
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.util.ImageImporter;
@@ -18,6 +19,48 @@ import net.imglib2.type.numeric.RealType;
 
 public class TileLoader
 {
+	public static enum TileType
+	{
+		IMAGE_FILE,
+		N5_DATASET
+	}
+
+	public static TileType getTileType( final TileInfo tile, final DataProvider dataProvider )
+	{
+		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
+
+		try
+		{
+			final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ) );
+			if ( n5.datasetExists( tileDatasetPath ) )
+				return TileType.N5_DATASET;
+		}
+		catch ( final IOException e )
+		{
+		}
+		return TileType.IMAGE_FILE;
+	}
+
+	public static String getChannelN5DatasetPath( final TileInfo tile )
+	{
+		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
+		return tileDatasetPath;
+	}
+
+	public static DatasetAttributes getTileN5DatasetAttributes( final TileInfo tile, final DataProvider dataProvider ) throws IOException
+	{
+		if ( getTileType( tile, dataProvider ) != TileType.N5_DATASET )
+			throw new IllegalArgumentException( "Expected the given tile to be an N5 dataset" );
+
+		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
+
+		final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ) );
+		return n5.getDatasetAttributes( tileDatasetPath );
+	}
+
 	public static < T extends NativeType< T > & RealType< T > > RandomAccessibleInterval< T > loadTile( final TileInfo tile, final DataProvider dataProvider )
 	{
 		// check if a given tile path is an N5 dataset

--- a/src/main/java/org/janelia/stitching/TileLoader.java
+++ b/src/main/java/org/janelia/stitching/TileLoader.java
@@ -1,0 +1,40 @@
+package org.janelia.stitching;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
+
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.PathResolver;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.util.ImageImporter;
+
+import ij.ImagePlus;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.imageplus.ImagePlusImgs;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+
+public class TileLoader
+{
+	public static < T extends NativeType< T > & RealType< T > > RandomAccessibleInterval< T > loadTile( final TileInfo tile, final DataProvider dataProvider )
+	{
+		// check if a given tile path is an N5 dataset
+		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
+
+		try
+		{
+			final N5Reader n5 = dataProvider.createN5Reader( URI.create( n5Path ) );
+			if ( n5.datasetExists( tileDatasetPath ) )
+				return N5Utils.open( n5, tileDatasetPath );
+		}
+		catch ( final IOException e )
+		{
+		}
+
+		final ImagePlus imp = ImageImporter.openImage( tile.getFilePath() );
+		return ImagePlusImgs.from( imp );
+	}
+}

--- a/src/main/java/org/janelia/stitching/TilesToN5Converter.java
+++ b/src/main/java/org/janelia/stitching/TilesToN5Converter.java
@@ -1,0 +1,155 @@
+package org.janelia.stitching;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderFactory;
+import org.janelia.saalfeldlab.n5.CompressionType;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.spark.N5WriterSupplier;
+import org.janelia.util.ImageImporter;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import ij.ImagePlus;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.imageplus.ImagePlusImgs;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.NumericType;
+
+public class TilesToN5Converter
+{
+	/**
+	 * Converts a stack of TIFF images to N5 breaking the images down into cells
+	 * with the block size in Z adjusted to the pixel resolution of the data.
+	 *
+	 * @param sparkContext
+	 * 			Spark context instantiated with {@link Kryo} serializer
+	 * @param n5Supplier
+	 * 			{@link N5Writer} supplier
+	 * @param tilesChannels
+	 * 			Input tile configurations for channels
+	 * @param blockSize
+	 * 			Output block size
+	 * @param compression
+	 * 			Output N5 compression
+	 * @throws IOException
+	 */
+	public static < T extends NumericType< T > & NativeType< T > > void convertTiffToN5(
+			final JavaSparkContext sparkContext,
+			final N5WriterSupplier n5Supplier,
+			final Map< String, TileInfo[] > tilesChannels,
+			final int blockSize,
+			final CompressionType n5Compression ) throws IOException
+	{
+		final int dimensionality = tilesChannels.values().iterator().next()[ 0 ].numDimensions();
+
+		final int[] blockSizeArr = new int[ dimensionality ];
+		Arrays.fill( blockSizeArr, blockSize );
+
+		// TODO: can consider pixel resolution to calculate isotropic block size in Z
+
+		for ( final Entry< String, TileInfo[] > entry : tilesChannels.entrySet() )
+		{
+			final String channelGroupName = Paths.get( entry.getKey() ).getFileName().toString();
+			n5Supplier.get().createGroup( channelGroupName );
+
+			sparkContext.parallelize( Arrays.asList( entry.getValue() ), entry.getValue().length ).foreach( tile ->
+				{
+					final N5Writer n5 = n5Supplier.get();
+					final String tileDatasetPath = Paths.get( channelGroupName, Paths.get( tile.getFilePath() ).getFileName().toString() ).toString();
+					final ImagePlus imp = ImageImporter.openImage( tile.getFilePath() );
+					final RandomAccessibleInterval< T > img = ImagePlusImgs.from( imp );
+					N5Utils.save( img, n5, tileDatasetPath, blockSizeArr, n5Compression );
+				}
+			);
+		}
+	}
+
+	public static void main( final String... args ) throws IOException
+	{
+		final Arguments parsedArgs = new Arguments( args );
+		if ( !parsedArgs.parsedSuccessfully() )
+			System.exit( 1 );
+
+		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
+				.setAppName( "TilesToN5Spark" )
+				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+			) )
+		{
+			final DataProvider tilesConfigDataProvider = DataProviderFactory.createByURI( URI.create( parsedArgs.getInputChannelsPath().get( 0 ) ) );
+			final Map< String, TileInfo[] > tilesChannels = new LinkedHashMap<>();
+			for ( final String inputPath : parsedArgs.getInputChannelsPath() )
+				tilesChannels.put( inputPath, TileInfoJSONProvider.loadTilesConfiguration( tilesConfigDataProvider.getJsonReader( URI.create( inputPath ) ) ) );
+
+			final URI n5Uri = URI.create( parsedArgs.getN5OutputPath() );
+			final N5WriterSupplier n5Supplier = () -> DataProviderFactory.createByURI( n5Uri ).createN5Writer( n5Uri );
+
+			convertTiffToN5(
+					sparkContext,
+					n5Supplier,
+					tilesChannels,
+					parsedArgs.getBlockSize(),
+					parsedArgs.getN5Compression()
+				);
+		}
+
+		System.out.println( System.lineSeparator() + "Done" );
+	}
+
+	private static class Arguments
+	{
+		@Option(name = "-i", aliases = { "--inputConfigurationPath" }, required = true,
+				usage = "Path to an input tile configuration file. Multiple configurations (channels) can be passed at once.")
+		private List< String > inputChannelsPath;
+
+		@Option(name = "-o", aliases = { "--n5OutputPath" }, required = true,
+				usage = "Path to an N5 output container (can be a filesystem path or an Amazon S3 link).")
+		private String n5OutputPath;
+
+		@Option(name = "-b", aliases = { "--blockSize" }, required = false,
+				usage = "Output block size.")
+		private int blockSize = 128;
+
+		@Option(name = "-c", aliases = { "--n5Compression" }, required = false,
+				usage = "N5 compression.")
+		private CompressionType n5Compression = CompressionType.GZIP;
+
+		private boolean parsedSuccessfully = false;
+
+		public Arguments( final String... args ) throws IllegalArgumentException
+		{
+			final CmdLineParser parser = new CmdLineParser( this );
+			try
+			{
+				parser.parseArgument( args );
+				parsedSuccessfully = true;
+			}
+			catch ( final CmdLineException e )
+			{
+				System.err.println( e.getMessage() );
+				parser.printUsage( System.err );
+			}
+		}
+
+		public boolean parsedSuccessfully() { return parsedSuccessfully; }
+
+		public List< String > getInputChannelsPath() { return inputChannelsPath; }
+		public String getN5OutputPath() { return n5OutputPath; }
+		public int getBlockSize() { return blockSize; }
+		public CompressionType getN5Compression() { return n5Compression; }
+	}
+}

--- a/src/main/java/org/janelia/stitching/TilesToN5Converter.java
+++ b/src/main/java/org/janelia/stitching/TilesToN5Converter.java
@@ -163,7 +163,7 @@ public class TilesToN5Converter
 
 		@Option(name = "-b", aliases = { "--blockSize" }, required = false,
 				usage = "Output block size.")
-		private int blockSize = 128;
+		private int blockSize = 64;
 
 		@Option(name = "-c", aliases = { "--n5Compression" }, required = false,
 				usage = "N5 compression.")

--- a/src/main/java/org/janelia/stitching/TilesToN5Converter.java
+++ b/src/main/java/org/janelia/stitching/TilesToN5Converter.java
@@ -15,6 +15,7 @@ import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.dataaccess.DataProviderType;
 import org.janelia.dataaccess.PathResolver;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudOAuth;
+import org.janelia.saalfeldlab.googlecloud.GoogleCloudResourceManagerClient;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudStorageClient;
 import org.janelia.saalfeldlab.n5.CompressionType;
 import org.janelia.saalfeldlab.n5.N5Writer;
@@ -59,7 +60,10 @@ public class TilesToN5Converter
 			if ( type == DataProviderType.GOOGLE_CLOUD )
 			{
 				final GoogleCloudOAuth oauth = new GoogleCloudOAuth(
-						Arrays.asList( GoogleCloudStorageClient.StorageScope.READ_WRITE ),
+						Arrays.asList(
+								GoogleCloudResourceManagerClient.ProjectsScope.READ_ONLY,
+								GoogleCloudStorageClient.StorageScope.READ_WRITE
+							),
 						"n5-viewer-google-cloud-oauth2",  // TODO: create separate application?
 						TilesToN5Converter.class.getResourceAsStream("/googlecloud_client_secrets.json")
 					);

--- a/src/main/java/org/janelia/stitching/Utils.java
+++ b/src/main/java/org/janelia/stitching/Utils.java
@@ -1,7 +1,6 @@
 package org.janelia.stitching;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -10,6 +9,7 @@ import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.janelia.dataaccess.PathResolver;
 import org.janelia.util.Conversions;
 
 import ij.IJ;
@@ -60,18 +60,9 @@ public class Utils {
 		return ret.toString();
 	}
 
-	public static String getAbsoluteImagePath( final StitchingJob job, final TileInfo tile )
-	{
-		String filePath = tile.getFilePath();
-		if ( !Paths.get( filePath ).isAbsolute() )
-			filePath = Paths.get( job.getBaseFolder(), filePath ).toString();
-		return filePath;
-	}
-
 	public static ImageCollectionElement createElement( final StitchingJob job, final TileInfo tile ) throws Exception
 	{
-		final File file = new File( job == null ? tile.getFilePath() : getAbsoluteImagePath( job, tile) );
-		final ImageCollectionElement e = new ImageCollectionElement( file, tile.getIndex() );
+		final ImageCollectionElement e = new ImageCollectionElement( new File( tile.getFilePath() ), tile.getIndex() );
 		e.setOffset( Conversions.toFloatArray( tile.getPosition() ) );
 		e.setDimensionality( tile.numDimensions() );
 		e.setModel( TileModelFactory.createOffsetModel( tile ) );
@@ -200,7 +191,7 @@ public class Utils {
 
 	public static int[] getTileCoordinates( final TileInfo tile ) throws Exception
 	{
-		return getTileCoordinates( Paths.get( tile.getFilePath() ).getFileName().toString() );
+		return getTileCoordinates( PathResolver.getFileName( tile.getFilePath() ) );
 	}
 	public static int[] getTileCoordinates( final String filename ) throws Exception
 	{
@@ -221,7 +212,7 @@ public class Utils {
 	}
 	public static String getTileCoordinatesString( final TileInfo tile ) throws Exception
 	{
-		return getTileCoordinatesString( Paths.get( tile.getFilePath() ).getFileName().toString() );
+		return getTileCoordinatesString( PathResolver.getFileName( tile.getFilePath() ) );
 	}
 	public static String getTileCoordinatesString( final String filename ) throws Exception
 	{
@@ -249,7 +240,7 @@ public class Utils {
 
 	public static long getTileTimestamp( final TileInfo tile ) throws Exception
 	{
-		return getTileTimestamp( Paths.get( tile.getFilePath() ).getFileName().toString() );
+		return getTileTimestamp( PathResolver.getFileName( tile.getFilePath() ) );
 	}
 	public static long getTileTimestamp( final String filename ) throws Exception
 	{

--- a/src/main/java/org/janelia/stitching/analysis/AddMissingTiles.java
+++ b/src/main/java/org/janelia/stitching/analysis/AddMissingTiles.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -32,8 +33,8 @@ public class AddMissingTiles
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		// Read inputs
-		final TreeMap< Integer, TileInfo > tilesInfoFinal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TreeMap< Integer, TileInfo > tilesInfoFinal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		final List< TileInfo > tilesInfoAdded = new ArrayList<>();
 		final TreeMap< Integer, TileInfo > initialTilesInfo = Utils.createTilesMapMulti( shiftsMulti, false );
@@ -571,7 +572,7 @@ public class AddMissingTiles
 			//System.out.println( t.getPosition(0)+" "+t.getPosition(1)+" "+t.getPosition(2) );
 		}
 
-		TileInfoJSONProvider.saveTilesConfiguration( tilesInfoFinal.values().toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_all" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tilesInfoFinal.values().toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_all" ) ) ) );
 
 
 		System.out.println( "Done" );

--- a/src/main/java/org/janelia/stitching/analysis/AddMissingTilesAverageShift.java
+++ b/src/main/java/org/janelia/stitching/analysis/AddMissingTilesAverageShift.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,8 +42,8 @@ public class AddMissingTilesAverageShift
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		// Read inputs
-		final TreeMap< Integer, TileInfo > tilesInfoOriginal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final TreeMap< Integer, TileInfo > tilesInfoFinal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final TreeMap< Integer, TileInfo > tilesInfoOriginal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final TreeMap< Integer, TileInfo > tilesInfoFinal = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 
 		parseCoordinates( tilesInfoOriginal.values() );
 
@@ -105,7 +106,7 @@ public class AddMissingTilesAverageShift
 		//for ( final TileInfo tileFinal : tilesInfoFinal.values() )
 		//	System.out.println( (missingTilesInfo.containsKey(tileFinal.getIndex())?"***":"") + Arrays.toString(tileFinal.getPosition()));
 
-		TileInfoJSONProvider.saveTilesConfiguration( tilesInfoFinal.values().toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 1 ], "_all" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tilesInfoFinal.values().toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 1 ], "_all" ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/AddMissingTilesMultichannel.java
+++ b/src/main/java/org/janelia/stitching/analysis/AddMissingTilesMultichannel.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -36,9 +37,9 @@ public class AddMissingTilesMultichannel
 		final TreeMap< Integer, TileInfo >[] tilesFinal = new TreeMap[ 2 ];
 		final List< SerializablePairWiseStitchingResult >[] shifts = new List[ 2 ];
 		for ( int ch = 0; ch < 2; ch++ )
-			tilesFinal[ ch ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ ch ] ) ) );
+			tilesFinal[ ch ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ ch ] ) ) ) );
 		for ( int ch = 0; ch < 2; ch++ )
-			shifts[ ch ] = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ tilesFinal.length + ch ] ) );
+			shifts[ ch ] = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ tilesFinal.length + ch ] ) ) );
 
 		// Find "tile indices offset" between corresponding tiles across channels
 		final int tilesPerChannel = Utils.createTilesMap( shifts[ 0 ], false ).size();

--- a/src/main/java/org/janelia/stitching/analysis/ChangeTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/ChangeTileConfiguration.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
@@ -23,8 +24,8 @@ public class ChangeTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TreeMap<Integer,TileInfo> tilesFrom = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final TreeMap<Integer, TileInfo > tilesTo = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final TreeMap<Integer,TileInfo> tilesFrom = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final TreeMap<Integer, TileInfo > tilesTo = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 		final String what = args[ 2 ].trim();
 
 		final int tilesPerChannel = tilesTo.size();
@@ -63,7 +64,7 @@ public class ChangeTileConfiguration
 		System.out.println( "Processed: " + processed );
 
 		final TileInfo[] result = new ArrayList<>( tilesTo.values() ).toArray( new TileInfo[0] );
-		TileInfoJSONProvider.saveTilesConfiguration( result, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 1 ], "_changed_" + what ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( result, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 1 ], "_changed_" + what ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/ChangeTilesOrder.java
+++ b/src/main/java/org/janelia/stitching/analysis/ChangeTilesOrder.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public class ChangeTilesOrder
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		final List< TileInfo >[] channels = new ArrayList[] { new ArrayList<>(), new ArrayList<>() };
 		for ( final TileInfo tile : tiles)
@@ -40,6 +41,6 @@ public class ChangeTilesOrder
 			allTiles.get( i ).setType( ImageType.GRAY16 );
 		}
 
-		TileInfoJSONProvider.saveTilesConfiguration( allTiles.toArray( new TileInfo[0] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[0], "_out" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( allTiles.toArray( new TileInfo[0] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[0], "_out" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/CheckChannelsIndexOrder.java
+++ b/src/main/java/org/janelia/stitching/analysis/CheckChannelsIndexOrder.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,7 @@ public class CheckChannelsIndexOrder
 
 		final List< TileInfo[] > channels = new ArrayList<>();
 		for (final String s : args)
-			channels.add( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( s ) ) );
+			channels.add( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( s ) ) ) );
 
 		final int n = channels.get(0).length;
 		for (int c = 0; c < channels.size(); c++ )

--- a/src/main/java/org/janelia/stitching/analysis/CheckConnectedGraphs.java
+++ b/src/main/java/org/janelia/stitching/analysis/CheckConnectedGraphs.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +37,7 @@ public class CheckConnectedGraphs
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tileInfos = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tileInfos = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final TreeMap< Integer, TileInfo > tilesMap = Utils.createTilesMap( tileInfos );
 
 		System.out.println( "Finding overlapping pairs.." );

--- a/src/main/java/org/janelia/stitching/analysis/CheckPairwiseShift.java
+++ b/src/main/java/org/janelia/stitching/analysis/CheckPairwiseShift.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public class CheckPairwiseShift
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		final int i1 = 1126;
 		final int i2 = 1129;

--- a/src/main/java/org/janelia/stitching/analysis/ChooseBestPeak.java
+++ b/src/main/java/org/janelia/stitching/analysis/ChooseBestPeak.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,7 +17,7 @@ public class ChooseBestPeak
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( args[0] ) );
+		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( args[0] ) ) );
 		final List< SerializablePairWiseStitchingResult > shifts = new ArrayList<>();
 
 		for ( final SerializablePairWiseStitchingResult[] shiftMulti : shiftsMulti )
@@ -28,6 +29,6 @@ public class ChooseBestPeak
 				valid++;
 		System.out.println( "There are " + valid + " valid pairs out of " + shifts.size() );
 
-		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[0], "_best" ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[0], "_best" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/ChooseRandomShiftsSubset.java
+++ b/src/main/java/org/janelia/stitching/analysis/ChooseRandomShiftsSubset.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -16,7 +17,7 @@ public class ChooseRandomShiftsSubset
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List<SerializablePairWiseStitchingResult> origShifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[0] ) );
+		final List<SerializablePairWiseStitchingResult> origShifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[0] ) ) );
 		final ArrayList<SerializablePairWiseStitchingResult> finalShifts = new ArrayList<>();
 		final double prob = 0.01;
 		final Random rnd = new Random();
@@ -45,6 +46,6 @@ public class ChooseRandomShiftsSubset
 
 		System.out.println( "origCount="+origCount );
 		System.out.println( "finalCount="+finalCount );
-		TileInfoJSONProvider.savePairwiseShifts( finalShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix(args[0], "_subset") ) );
+		TileInfoJSONProvider.savePairwiseShifts( finalShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix(args[0], "_subset") ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/ChooseSameSubset.java
+++ b/src/main/java/org/janelia/stitching/analysis/ChooseSameSubset.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
@@ -16,8 +17,8 @@ public class ChooseSameSubset {
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > origShifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[0] ) );
-		final TreeMap<Integer, TreeMap<Integer, SerializablePairWiseStitchingResult>> subsetShiftsMap = Utils.createPairwiseShiftsMap(TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[1] ) ), false);
+		final List< SerializablePairWiseStitchingResult > origShifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[0] ) ) );
+		final TreeMap<Integer, TreeMap<Integer, SerializablePairWiseStitchingResult>> subsetShiftsMap = Utils.createPairwiseShiftsMap(TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[1] ) ) ), false);
 		final ArrayList< SerializablePairWiseStitchingResult > finalShifts = new ArrayList<>();
 
 		int totalCount = 0, finalCount = 0;
@@ -41,6 +42,6 @@ public class ChooseSameSubset {
 		System.out.println("totalCount="+totalCount);
 		System.out.println("finalCount="+finalCount);
 
-		TileInfoJSONProvider.savePairwiseShifts( finalShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix(args[0], "_subset") ) );
+		TileInfoJSONProvider.savePairwiseShifts( finalShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix(args[0], "_subset") ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/CompareOverlap.java
+++ b/src/main/java/org/janelia/stitching/analysis/CompareOverlap.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -26,7 +27,7 @@ public class CompareOverlap
 		String filename = args[ 0 ];
 		final int i1 = Integer.parseInt( args[ 1 ] ), i2 = Integer.parseInt( args[ 2 ] );
 		System.out.println( "Tiles " + i1 + " and " + i2 + ":" );
-		TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( filename ) );
+		TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( filename ) ) );
 		ArrayList< TileInfo > twoTiles = new ArrayList<>();
 		for ( final TileInfo tile : tiles )
 			if ( tile.getIndex() == i1 || tile.getIndex() == i2 )
@@ -47,7 +48,7 @@ public class CompareOverlap
 
 
 		filename = Utils.addFilenameSuffix( Utils.removeFilenameSuffix( filename, "_full" ), "_shifted" );
-		tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( filename ) );
+		tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( filename ) ) );
 		TileOperations.translateTilesToOrigin( tiles );
 		twoTiles = new ArrayList<>();
 		for ( final TileInfo tile : tiles )

--- a/src/main/java/org/janelia/stitching/analysis/CompareOverlaps.java
+++ b/src/main/java/org/janelia/stitching/analysis/CompareOverlaps.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.TreeSet;
 
@@ -33,8 +34,8 @@ public class CompareOverlaps
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TileInfo[] tilesMod  = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TileInfo[] tilesMod  = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		TileOperations.translateTilesToOrigin( tilesOrig );
 		TileOperations.translateTilesToOrigin( tilesMod  );

--- a/src/main/java/org/janelia/stitching/analysis/CompareTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/CompareTileConfiguration.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.TreeMap;
 
 import org.janelia.dataaccess.DataProvider;
@@ -14,8 +15,8 @@ public class CompareTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TreeMap<Integer,TileInfo> tilesBefore = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final TreeMap<Integer, TileInfo > tilesAfter = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final TreeMap<Integer,TileInfo> tilesBefore = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final TreeMap<Integer, TileInfo > tilesAfter = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 
 		System.out.println( "Tiles before: " + tilesBefore.size() );
 		System.out.println( "Tiles after: " + tilesAfter.size() );

--- a/src/main/java/org/janelia/stitching/analysis/CopyTilesPositions.java
+++ b/src/main/java/org/janelia/stitching/analysis/CopyTilesPositions.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
@@ -17,8 +18,8 @@ public class CopyTilesPositions
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tilesCopyFrom = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TreeMap< Integer, TileInfo > tilesMapCopyTo = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final TileInfo[] tilesCopyFrom = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TreeMap< Integer, TileInfo > tilesMapCopyTo = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 		final List< TileInfo > tilesTo = new ArrayList<>();
 		for ( final TileInfo tileCopyFrom : tilesCopyFrom )
 		{
@@ -29,6 +30,6 @@ public class CopyTilesPositions
 		System.out.println( "tilesCopyFrom size="+tilesCopyFrom.length);
 		System.out.println( "tilesMapCopyTo size="+tilesMapCopyTo.size() );
 		System.out.println( "tilesTo size="+tilesTo.size() );
-		TileInfoJSONProvider.saveTilesConfiguration( tilesTo.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 1 ], "_final" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tilesTo.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 1 ], "_final" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/CreateFakePairwiseShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/CreateFakePairwiseShifts.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +24,7 @@ public class CreateFakePairwiseShifts
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final List< TilePair > overlappingPairs = TileOperations.findOverlappingTiles( tiles );
 		final List< SerializablePairWiseStitchingResult > nonAdjacentShifts = new ArrayList<>();
 
@@ -90,7 +91,7 @@ public class CreateFakePairwiseShifts
 		System.out.println( "Adjacent pairs for Y = " + adjShiftsCount[1]);
 		System.out.println( "Adjacent pairs for Z = " + adjShiftsCount[2]);
 
-		TileInfoJSONProvider.savePairwiseShifts( nonAdjacentShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_pairwise_fake" ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( nonAdjacentShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_pairwise_fake" ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/DistanceFromOriginal.java
+++ b/src/main/java/org/janelia/stitching/analysis/DistanceFromOriginal.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -30,8 +31,8 @@ public class DistanceFromOriginal
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TileInfo[] tilesMod  = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TileInfo[] tilesMod  = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		TileOperations.translateTilesToOrigin( tilesOrig );
 		TileOperations.translateTilesToOrigin( tilesMod  );

--- a/src/main/java/org/janelia/stitching/analysis/EstimateErrors.java
+++ b/src/main/java/org/janelia/stitching/analysis/EstimateErrors.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,8 +25,8 @@ public class EstimateErrors
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final Map< Integer, TileInfo > originalTiles = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final TileInfo[] resultingTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final Map< Integer, TileInfo > originalTiles = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final TileInfo[] resultingTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		parseCoordinates( resultingTiles );
 		parseTimestamps( resultingTiles );

--- a/src/main/java/org/janelia/stitching/analysis/ExtractShiftsForTile.java
+++ b/src/main/java/org/janelia/stitching/analysis/ExtractShiftsForTile.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,7 +19,7 @@ public class ExtractShiftsForTile
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final int tileIndex = Integer.parseInt( args[ 1 ] );
 
 		final List< SerializablePairWiseStitchingResult > shiftsForTile = new ArrayList<>();

--- a/src/main/java/org/janelia/stitching/analysis/ExtractSlice.java
+++ b/src/main/java/org/janelia/stitching/analysis/ExtractSlice.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -31,7 +32,7 @@ public class ExtractSlice
 			final String outFolder = Paths.get( input ).getParent().toString() + "/slice" + slice;
 			new File(outFolder).mkdirs();
 
-			final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( input ) );
+			final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( input ) ) );
 			final JavaRDD< TileInfo > rdd = sparkContext.parallelize( Arrays.asList( tiles ) );
 			final TileInfo[] sliceTiles = rdd.map( tile ->
 				{
@@ -48,7 +49,7 @@ public class ExtractSlice
 				}
 			).collect().toArray( new TileInfo[ 0 ] );
 
-			TileInfoJSONProvider.saveTilesConfiguration( sliceTiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix( input, "_slice" + slice ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( sliceTiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( input, "_slice" + slice ) ) ) );
 		}
 
 		System.out.println("Done");

--- a/src/main/java/org/janelia/stitching/analysis/ExtractTilePosition.java
+++ b/src/main/java/org/janelia/stitching/analysis/ExtractTilePosition.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Map;
@@ -17,7 +18,7 @@ public class ExtractTilePosition
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		TileOperations.translateTilesToOriginReal( tiles );
 		final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( tiles );
 		for ( final int i : new int[] { 18299, 18300 } )

--- a/src/main/java/org/janelia/stitching/analysis/FilterAdjacentShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterAdjacentShifts.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,7 +29,7 @@ public class FilterAdjacentShifts
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final String dimStr = args.length > 1 ? args[ 1 ] : "";
 		if ( !dimStr.isEmpty() && !dimStr.equals( "x" ) && !dimStr.equals("y") && !dimStr.equals( "z" ) )
 			throw new Exception( "Unknown value" );
@@ -167,7 +168,7 @@ public class FilterAdjacentShifts
 
 
 		System.out.println( "There are " + adjacentShifts.size() + " adjacent shifts of " + validShifts );
-		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_adj" + (!dimStr.isEmpty()?"-"+dimStr:"" ) ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_adj" + (!dimStr.isEmpty()?"-"+dimStr:"" ) ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/FilterAdjacentShiftsMulti.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterAdjacentShiftsMulti.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -28,7 +29,7 @@ public class FilterAdjacentShiftsMulti
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult[] > shifts = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult[] > shifts = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final String dimStr = args.length > 1 ? args[ 1 ] : "";
 		if ( !dimStr.isEmpty() && !dimStr.equals( "x" ) && !dimStr.equals("y") && !dimStr.equals( "z" ) )
 			throw new Exception( "Unknown value" );
@@ -171,7 +172,7 @@ public class FilterAdjacentShiftsMulti
 
 
 		System.out.println( "There are " + adjacentShifts.size() + " adjacent shifts of " + validShifts );
-		TileInfoJSONProvider.savePairwiseShiftsMulti( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_adj" + (!dimStr.isEmpty()?"-"+dimStr:"" ) ) ) );
+		TileInfoJSONProvider.savePairwiseShiftsMulti( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_adj" + (!dimStr.isEmpty()?"-"+dimStr:"" ) ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/FilterOutliers.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterOutliers.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.List;
 
 import org.janelia.dataaccess.DataProvider;
@@ -23,7 +24,7 @@ public class FilterOutliers
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		int before = 0, after = 0;
 		for ( int i = 0; i < shifts.size(); i++ )
@@ -48,7 +49,7 @@ public class FilterOutliers
 
 		System.out.println( "before="+before + ", after="+after);
 
-		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_inliers" ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_inliers" ) ) ) );
 	}
 
 
@@ -59,7 +60,7 @@ public class FilterOutliers
 
 		final List< SerializablePairWiseStitchingResult >[] shifts = new List[2];
 		for ( int j = 0; j < 2; j++ )
-			shifts[j]=TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ j ] ) );
+			shifts[j]=TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ j ] ) ) );
 
 		//final Point zero = new Point( new double[ ch0Shifts.get( 0 ).getNumDimensions() ] );
 		//final List< PairwiseShiftPointMatch > matches = new ArrayList<>(), inliers = new ArrayList<>();
@@ -113,7 +114,7 @@ public class FilterOutliers
 		//	match.getShift().setIsValidOverlap( true );
 
 		for ( int j = 0; j < 2; j++ )
-			TileInfoJSONProvider.savePairwiseShifts( shifts[j], dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ j ], "_inliers" ) ) );
+			TileInfoJSONProvider.savePairwiseShifts( shifts[j], dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ j ], "_inliers" ) ) ) );
 	}
 
 

--- a/src/main/java/org/janelia/stitching/analysis/FilterPairwiseShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterPairwiseShifts.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -21,7 +22,7 @@ public class FilterPairwiseShifts
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		final TileInfo[] tiles = Utils.createTilesMap( shifts, true ).values().toArray( new TileInfo[ 0 ] );
 		final Map< Integer, int[] > tileIndexToCoordinates = new HashMap<>();
@@ -39,6 +40,6 @@ public class FilterPairwiseShifts
 
 		System.out.println( "Size before = " + sizeBefore + ", size after = " + sizeAfter );
 
-		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_without_z" ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_without_z" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/FilterStageCoordinates.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterStageCoordinates.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class FilterStageCoordinates
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		final int d = 2;
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final List< Pair< TileInfo, int[] > > tileCoords = Utils.getTilesCoordinates( Utils.createTilesMap( shifts, true ).values().toArray( new TileInfo[ 0 ] ) );
 		System.out.println("There are "+tileCoords.size()+" tiles and " + shifts.size() + " pairwise shifts");
 
@@ -58,8 +59,8 @@ public class FilterStageCoordinates
 			System.out.println("There are "+tilesDesired.length+" desired tiles and " + shiftsDesired.size() + " desired pairwise shifts");
 
 			final String newConfigPath = Utils.addFilenameSuffix(args[0], "_"+z+"z" ) ;
-			TileInfoJSONProvider.saveTilesConfiguration( tilesDesired, dataProvider.getJsonWriter( newConfigPath ) );
-			TileInfoJSONProvider.savePairwiseShifts( shiftsDesired, dataProvider.getJsonWriter( Utils.addFilenameSuffix(newConfigPath, "_pairwise") ) );
+			TileInfoJSONProvider.saveTilesConfiguration( tilesDesired, dataProvider.getJsonWriter( URI.create( newConfigPath ) ) );
+			TileInfoJSONProvider.savePairwiseShifts( shiftsDesired, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix(newConfigPath, "_pairwise") ) ) );
 		}
 	}
 

--- a/src/main/java/org/janelia/stitching/analysis/FilterTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterTileConfiguration.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.TreeSet;
@@ -49,7 +50,7 @@ public class FilterTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilename ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilename ) ) );
 		System.out.println( "Total number of tiles = " + tiles.length );
 
 		final ArrayList< TileInfo > filteredTiles = new ArrayList<>();
@@ -58,26 +59,26 @@ public class FilterTileConfiguration
 				filteredTiles.add( tile );
 
 		System.out.println( "Number of tiles after filtering = " + filteredTiles.size() );
-		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilename, "_filtered_" + filenameFilter ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilename, "_filtered_" + filenameFilter ) ) ) );
 	}
 
 	public static void filterByTileIndexes( final String inputFilename, final Set< Integer > tileIndexes ) throws IOException
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilename ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilename ) ) );
 		final ArrayList< TileInfo > filteredTiles = new ArrayList<>();
 		for ( final TileInfo tile : tiles )
 			if ( tileIndexes.contains( tile.getIndex() ) )
 				filteredTiles.add( tile );
-		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilename, "_filtered_" + tileIndexes.toString().replaceAll( " ", "" ) ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilename, "_filtered_" + tileIndexes.toString().replaceAll( " ", "" ) ) ) ) );
 	}
 
 	public static void filterByTileIndexesExcluded( final String inputFilename, final Set< Integer > tileIndexesExcluded ) throws IOException
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilename ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilename ) ) );
 		System.out.println( "Before: " + tiles.length + " tiles" );
 		System.out.println( "Excluding " + tileIndexesExcluded.size() + " tiles.." );
 
@@ -87,6 +88,6 @@ public class FilterTileConfiguration
 				filteredTiles.add( tile );
 
 		System.out.println( "After: " + filteredTiles.size() + " tiles" );
-		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilename, "_excluded_" + tileIndexesExcluded.size() + "_tiles" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( filteredTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilename, "_excluded_" + tileIndexesExcluded.size() + "_tiles" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/FilterTileDuplicates.java
+++ b/src/main/java/org/janelia/stitching/analysis/FilterTileDuplicates.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,7 +22,7 @@ public class FilterTileDuplicates
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		System.out.println( "Total number of tiles = " + tiles.length );
 
 		// build a map of tile coordinates to find duplicates
@@ -77,7 +78,7 @@ public class FilterTileDuplicates
 		else
 		{
 			System.out.println( String.format("Removed %d duplicated tiles out of %d tiles", tiles.length - retainedTiles.size(), tiles.length ) );
-			TileInfoJSONProvider.saveTilesConfiguration( retainedTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_retained" ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( retainedTiles.toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_retained" ) ) ) );
 		}
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/FindPairwiseChanges.java
+++ b/src/main/java/org/janelia/stitching/analysis/FindPairwiseChanges.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -23,8 +24,8 @@ public class FindPairwiseChanges
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] stageTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TileInfo[] stitchedTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TileInfo[] stageTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TileInfo[] stitchedTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		final List< TilePair > adjacentPairs = FilterAdjacentShifts.filterAdjacentPairs( TileOperations.findOverlappingTiles( stageTiles ) );
 		final List< TilePair > newAdjacentPairs = getPairsWithPrediction( stageTiles, stitchedTiles, 5, true );

--- a/src/main/java/org/janelia/stitching/analysis/FindParticularShift.java
+++ b/src/main/java/org/janelia/stitching/analysis/FindParticularShift.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class FindParticularShift
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		final int i1 = Integer.parseInt( args[ 1 ] ), i2 = Integer.parseInt( args[ 2 ] );
 		System.out.println( "Tiles " + i1 + " and " + i2 + ":" );
@@ -61,7 +62,7 @@ public class FindParticularShift
 		Boundaries overlap = TileOperations.getOverlappingRegionGlobal( t1, t2 );
 		System.out.println( "Initial overlap at " + Arrays.toString( overlap.getMin() ) + " with dimensions " + Arrays.toString( overlap.getDimensions() ) );
 
-		TileInfoJSONProvider.saveTilesConfiguration( new TileInfo[] { t1, t2 }, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[0], "_ORIGINAL" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( new TileInfo[] { t1, t2 }, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[0], "_ORIGINAL" ) ) ) );
 
 		for ( int d = 0; d < shift.getNumDimensions(); d++ )
 			t2.setPosition( d, t1.getPosition( d ) + shift.getOffset( d ) );
@@ -72,6 +73,6 @@ public class FindParticularShift
 		else
 			System.out.println( "*** No overlap after applying the offset! ***" );
 
-		TileInfoJSONProvider.saveTilesConfiguration( new TileInfo[] { t1, t2 }, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[0], "_SHIFTED" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( new TileInfo[] { t1, t2 }, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[0], "_SHIFTED" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/FindTilesAtPoint.java
+++ b/src/main/java/org/janelia/stitching/analysis/FindTilesAtPoint.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,7 +25,7 @@ public class FindTilesAtPoint
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		TileOperations.translateTilesToOriginReal( tiles );
 
 		final double[] point = Conversions.parseDoubleArray( args[ 1 ].split( "," ) );

--- a/src/main/java/org/janelia/stitching/analysis/FindWorstShift.java
+++ b/src/main/java/org/janelia/stitching/analysis/FindWorstShift.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.List;
 
 import org.janelia.dataaccess.DataProvider;
@@ -27,7 +28,7 @@ public class FindWorstShift
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		int validShiftsCount = 0;
 		int badShiftsCount = 0;
@@ -109,7 +110,7 @@ public class FindWorstShift
 		if ( badShiftsCount > 0)
 		{
 			System.out.println( "Filtering out bad shifts" );
-			TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_good" ) ) );
+			TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_good" ) ) ) );
 		}
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/FixTilePosition.java
+++ b/src/main/java/org/janelia/stitching/analysis/FixTilePosition.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public class FixTilePosition
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final int tileIndex = Integer.parseInt( args[ 1 ] );
 		final int dimToFix = Integer.parseInt( args[ 2 ] );
 		final double newVal = Double.parseDouble( args[ 3 ] );
@@ -27,16 +28,16 @@ public class FixTilePosition
 				tile.setPosition( dimToFix, newVal );
 
 		final String outFilename = Utils.addFilenameSuffix( args[ 0 ], "_fixed_" + tileIndex + "_" + (dimToFix==0?"x":(dimToFix==1?"y":"z")) );
-		TileInfoJSONProvider.saveTilesConfiguration( tiles, dataProvider.getJsonWriter( outFilename ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tiles, dataProvider.getJsonWriter( URI.create( outFilename ) ) );
 
 		try
 		{
-			final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( Utils.addFilenameSuffix( args[ 0 ], "_pairwise" ) ) );
+			final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_pairwise" ) ) ) );
 			final List< SerializablePairWiseStitchingResult > fixedShifts = new ArrayList<>();
 			for ( final SerializablePairWiseStitchingResult shift : shifts )
 				if ( shift.getTilePair().getA().getIndex() != tileIndex && shift.getTilePair().getB().getIndex() != tileIndex )
 					fixedShifts.add( shift );
-			TileInfoJSONProvider.savePairwiseShifts( fixedShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( outFilename, "_pairwise" ) ) );
+			TileInfoJSONProvider.savePairwiseShifts( fixedShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( outFilename, "_pairwise" ) ) ) );
 		}
 		catch ( final IOException e )
 		{

--- a/src/main/java/org/janelia/stitching/analysis/GroupTilesByTimestamp.java
+++ b/src/main/java/org/janelia/stitching/analysis/GroupTilesByTimestamp.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -19,7 +20,7 @@ public class GroupTilesByTimestamp
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		for ( int i = 1; i < tiles.length; i++ )
 			if ( tiles[ i - 1].getIndex().intValue() + 1 != tiles[ i ].getIndex().intValue() )
 				throw new Exception( "Tiles are not sorted by index" );
@@ -42,7 +43,7 @@ public class GroupTilesByTimestamp
 		}
 
 		final String pairwiseSuffix = "_pairwise";
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( Utils.addFilenameSuffix( args[ 0 ], pairwiseSuffix ) ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( Utils.addFilenameSuffix( args[ 0 ], pairwiseSuffix ) ) ) );
 		for ( int i = 0; i < tileGroups.size(); i++ )
 		{
 			final Set< Integer > groupTileIndexes = new HashSet<>();
@@ -54,8 +55,8 @@ public class GroupTilesByTimestamp
 					groupShifts.add( shift );
 
 			final String groupSuffix = "_group" + i;
-			TileInfoJSONProvider.saveTilesConfiguration( tileGroups.get( i ).toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], groupSuffix ) ) );
-			TileInfoJSONProvider.savePairwiseShifts( groupShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( Utils.addFilenameSuffix( args[ 0 ], groupSuffix ), pairwiseSuffix ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( tileGroups.get( i ).toArray( new TileInfo[ 0 ] ), dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], groupSuffix ) ) ) );
+			TileInfoJSONProvider.savePairwiseShifts( groupShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( Utils.addFilenameSuffix( args[ 0 ], groupSuffix ), pairwiseSuffix ) ) ) );
 		}
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/IndexTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/IndexTileConfiguration.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
@@ -14,10 +15,10 @@ public class IndexTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[0] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[0] ) ) );
 		for ( int i = 0; i < tiles.length; i++ )
 			tiles[ i ].setIndex( i );
 
-		TileInfoJSONProvider.saveTilesConfiguration(tiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix(args[0], "_indexed" ) ));
+		TileInfoJSONProvider.saveTilesConfiguration(tiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix(args[0], "_indexed" ) )) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/MarkValidShiftsMulti.java
+++ b/src/main/java/org/janelia/stitching/analysis/MarkValidShiftsMulti.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -15,8 +16,8 @@ public class MarkValidShiftsMulti
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shiftsFinal = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[0] ) );
-		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( args[1] ) );
+		final List< SerializablePairWiseStitchingResult > shiftsFinal = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[0] ) ) );
+		final List< SerializablePairWiseStitchingResult[] > shiftsMulti = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( args[1] ) ) );
 
 		final TreeMap< Integer, TreeMap< Integer, SerializablePairWiseStitchingResult > > shiftsFinalValidMap = Utils.createPairwiseShiftsMap( shiftsFinal, true );
 
@@ -54,6 +55,6 @@ public class MarkValidShiftsMulti
 
 		System.out.println( "Marked " + valid + " shifts as valid" );
 
-		TileInfoJSONProvider.savePairwiseShiftsMulti( shiftsMulti, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[1], "_final" ) ) );
+		TileInfoJSONProvider.savePairwiseShiftsMulti( shiftsMulti, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[1], "_final" ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/MergePairwiseShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/MergePairwiseShifts.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,7 @@ public class MergePairwiseShifts
 			else if (!workingDir.isEmpty() && !workingDir.equals( Paths.get( input ).getParent().toString()+"/" ))
 				workingDir="";
 
-			final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( input ) );
+			final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( input ) ) );
 			for ( final SerializablePairWiseStitchingResult shift : shifts )
 			{
 				final int ind1 = Math.min( shift.getTilePair().getA().getIndex(), shift.getTilePair().getB().getIndex() );
@@ -46,7 +47,7 @@ public class MergePairwiseShifts
 				mergedShifts.add( shift );
 
 		if ( !mergedShifts.isEmpty() )
-			TileInfoJSONProvider.savePairwiseShifts( mergedShifts, dataProvider.getJsonWriter( workingDir +"merged_pairwise_shifts_set.json" ) );
+			TileInfoJSONProvider.savePairwiseShifts( mergedShifts, dataProvider.getJsonWriter( URI.create( workingDir +"merged_pairwise_shifts_set.json" ) ) );
 
 
 		int valid = 0;

--- a/src/main/java/org/janelia/stitching/analysis/NonOverlappingShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/NonOverlappingShifts.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -29,7 +30,7 @@ public class NonOverlappingShifts
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		for ( final SerializablePairWiseStitchingResult shift : shifts )
 			if ( !shift.getIsValidOverlap() )

--- a/src/main/java/org/janelia/stitching/analysis/RenamePairwise.java
+++ b/src/main/java/org/janelia/stitching/analysis/RenamePairwise.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -22,8 +23,8 @@ public class RenamePairwise
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 1 ] ) );
+		final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		final Set< Integer > validation = new HashSet<>();
 		for ( final SerializablePairWiseStitchingResult shift : shifts )
@@ -40,7 +41,7 @@ public class RenamePairwise
 			shift.getTilePair().getB().setFilePath( tilesMap.get( shift.getTilePair().getB().getIndex() ).getFilePath() );
 		}
 
-		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 1 ], "_renamed" ) ) );
+		TileInfoJSONProvider.savePairwiseShifts( shifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 1 ], "_renamed" ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/RenameTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/RenameTileConfiguration.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,8 +22,8 @@ public class RenameTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TileInfo[] tilesToRename = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TileInfo[] tilesOrig = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TileInfo[] tilesToRename = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 		final String suffix = args.length > 2 ? args[ 2 ] : "";
 
 		if ( tilesOrig.length != tilesToRename.length )
@@ -46,7 +47,7 @@ public class RenameTileConfiguration
 			tilesToRename[ i ].setFilePath( newPath );
 		}
 
-		TileInfoJSONProvider.saveTilesConfiguration( tilesToRename, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 1 ], "_renamed" ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tilesToRename, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 1 ], "_renamed" ) ) ) );
 
 		System.out.println( "Done" );
 	}

--- a/src/main/java/org/janelia/stitching/analysis/ReplaceTilesPairwise.java
+++ b/src/main/java/org/janelia/stitching/analysis/ReplaceTilesPairwise.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -19,8 +20,8 @@ public class ReplaceTilesPairwise
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List<SerializablePairWiseStitchingResult> shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
-		final Map< Integer, TileInfo > tiles = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final List<SerializablePairWiseStitchingResult> shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final Map< Integer, TileInfo > tiles = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 
 		final List<SerializablePairWiseStitchingResult> newShifts = new ArrayList<>();
 		for ( final SerializablePairWiseStitchingResult shift : shifts )
@@ -32,6 +33,6 @@ public class ReplaceTilesPairwise
 					newTilePair, shift.getOffset().clone(), shift.getCrossCorrelation(), shift.getPhaseCorrelation() );
 			newShifts.add( newShift );
 		}
-		TileInfoJSONProvider.savePairwiseShifts( newShifts, dataProvider.getJsonWriter( Utils.addFilenameSuffix(args[1], "_pairwise") ) );
+		TileInfoJSONProvider.savePairwiseShifts( newShifts, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix(args[1], "_pairwise") ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/RescaleData.java
+++ b/src/main/java/org/janelia/stitching/analysis/RescaleData.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
 import java.nio.file.Paths;
 
 import org.janelia.dataaccess.DataProvider;
@@ -26,8 +27,8 @@ public class RescaleData {
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final TileInfo[] deconTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final TileInfo[] deconTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 		final int tileIndex = 1;
 		final TileInfo tile = tiles[ tileIndex ];
 		final TileInfo deconTile = deconTiles[ tileIndex ];

--- a/src/main/java/org/janelia/stitching/analysis/ScaleTileConfiguration.java
+++ b/src/main/java/org/janelia/stitching/analysis/ScaleTileConfiguration.java
@@ -1,5 +1,7 @@
 package org.janelia.stitching.analysis;
 
+import java.net.URI;
+
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
 import org.janelia.stitching.TileInfo;
@@ -16,13 +18,13 @@ public class ScaleTileConfiguration
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final int dimToScale = Integer.parseInt( args[ 1 ] );
 		final double scaleFactor = Double.parseDouble( args[ 2 ] );
 
 		for ( int i = 0; i < tiles.length; i++ )
 			tiles[ i ].setPosition( dimToScale, Math.floor( tiles[ i ].getPosition( dimToScale ) * scaleFactor ) );
 
-		TileInfoJSONProvider.saveTilesConfiguration( tiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix( args[ 0 ], "_scaled_" + (dimToScale==0?"x":(dimToScale==1?"y":"z")) ) ) );
+		TileInfoJSONProvider.saveTilesConfiguration( tiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( args[ 0 ], "_scaled_" + (dimToScale==0?"x":(dimToScale==1?"y":"z")) ) ) ) );
 	}
 }

--- a/src/main/java/org/janelia/stitching/analysis/ThresholdEstimation.java
+++ b/src/main/java/org/janelia/stitching/analysis/ThresholdEstimation.java
@@ -3,6 +3,7 @@ package org.janelia.stitching.analysis;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -225,7 +226,7 @@ public class ThresholdEstimation
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 
 		final List< SerializablePairWiseStitchingResult > validShifts = new ArrayList<>();
 		for ( final SerializablePairWiseStitchingResult shift : shifts )

--- a/src/main/java/org/janelia/stitching/analysis/TileInfoJSONToTxtConfigurationFormat.java
+++ b/src/main/java/org/janelia/stitching/analysis/TileInfoJSONToTxtConfigurationFormat.java
@@ -2,6 +2,7 @@ package org.janelia.stitching.analysis;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
@@ -20,7 +21,7 @@ public class TileInfoJSONToTxtConfigurationFormat
 		final String inputFilepath = args[ 0 ];
 		final String outputFilepath = inputFilepath.substring( 0, inputFilepath.lastIndexOf( "." ) ) + ".txt";
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		TileOperations.translateTilesToOriginReal( tiles );
 
 		try ( final PrintWriter writer = new PrintWriter( outputFilepath ) )

--- a/src/main/java/org/janelia/stitching/analysis/TilesCoverage.java
+++ b/src/main/java/org/janelia/stitching/analysis/TilesCoverage.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +27,8 @@ public class TilesCoverage
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final Map< Integer, TileInfo > initialTilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final Map< Integer, TileInfo > resultingTilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final Map< Integer, TileInfo > initialTilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final Map< Integer, TileInfo > resultingTilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 
 		final TreeMap< Integer, TileInfo > uncoveredTiles = new TreeMap<>( initialTilesMap );
 		uncoveredTiles.keySet().removeAll( resultingTilesMap.keySet() );

--- a/src/main/java/org/janelia/stitching/analysis/TilesPairwiseCoverage.java
+++ b/src/main/java/org/janelia/stitching/analysis/TilesPairwiseCoverage.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,8 +27,8 @@ public class TilesPairwiseCoverage
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) ) );
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 1 ] ) );
+		final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) );
 
 		int validShifts = 0;
 		//final Map< Integer, TileInfo > uncoveredTiles = Utils.createTilesMap( shifts );

--- a/src/main/java/org/janelia/stitching/analysis/TraceConfigurationsDistance.java
+++ b/src/main/java/org/janelia/stitching/analysis/TraceConfigurationsDistance.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -18,8 +19,8 @@ public class TraceConfigurationsDistance
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tilesBefore = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
-		final Map< Integer, TileInfo > tilesMapAfter = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 1 ] ) ) );
+		final TileInfo[] tilesBefore = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
+		final Map< Integer, TileInfo > tilesMapAfter = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 1 ] ) ) ) );
 
 		//final Integer dim = ;
 

--- a/src/main/java/org/janelia/stitching/analysis/TraceHighestCrossCorrelation.java
+++ b/src/main/java/org/janelia/stitching/analysis/TraceHighestCrossCorrelation.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 import org.janelia.dataaccess.DataProvider;
@@ -14,7 +15,7 @@ public class TraceHighestCrossCorrelation
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 0 ] ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		double maxCrossCorr = 0;
 		for ( final SerializablePairWiseStitchingResult shift : shifts )
 		{

--- a/src/main/java/org/janelia/stitching/analysis/TracePairwiseShifts.java
+++ b/src/main/java/org/janelia/stitching/analysis/TracePairwiseShifts.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class TracePairwiseShifts
 
 		final Map< Integer, TileInfo >[] channelsMap = new TreeMap[ args.length - 2 ];
 		for ( int i = 0; i < channelsMap.length; i++ )
-			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ i ] ) ) );
+			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ i ] ) ) ) );
 
 		for ( int i = 1; i < channelsMap.length; i++ )
 			if ( channelsMap[ i ].size() != channelsMap[ i - 1 ].size() )
@@ -33,7 +34,7 @@ public class TracePairwiseShifts
 			System.out.println( tilesPerChannel + " tiles per channel" );
 
 		final String pairwiseShiftsFilepath = args[ args.length - 2 ];
-		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( pairwiseShiftsFilepath ) );
+		final List< SerializablePairWiseStitchingResult > shifts = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( pairwiseShiftsFilepath ) ) );
 
 		final String outputFolder = args[ args.length - 1 ];
 

--- a/src/main/java/org/janelia/stitching/analysis/TracePairwiseShiftsForAllChannels.java
+++ b/src/main/java/org/janelia/stitching/analysis/TracePairwiseShiftsForAllChannels.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class TracePairwiseShiftsForAllChannels
 
 		final Map< Integer, TileInfo >[] channelsMap = new TreeMap[ 2 ];
 		for ( int i = 0; i < channelsMap.length; i++ )
-			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ i ] ) ) );
+			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ i ] ) ) ) );
 
 		// validate
 		for ( int i = 1; i < channelsMap.length; i++ )
@@ -36,15 +37,15 @@ public class TracePairwiseShiftsForAllChannels
 
 		final Map< Integer, TileInfo >[] channelsFinalMap = new TreeMap[ 2 ];
 		for ( int i = 0; i < channelsFinalMap.length; i++ )
-			channelsFinalMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 2 + i ] ) ) );
+			channelsFinalMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 2 + i ] ) ) ) );
 
 
 		final List< SerializablePairWiseStitchingResult >[] shifts = new List[ 2 ];
 		for ( int i = 0; i < shifts.length; i++ )
-			shifts[ i ] = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( args[ 4 + i ] ) );
+			shifts[ i ] = TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( args[ 4 + i ] ) ) );
 
 		final String pairwiseShiftsCombinedFilepath = args.length > 7 ? args[ args.length - 2 ] : "";
-		final List< SerializablePairWiseStitchingResult > shiftsForCombinedChannels = !pairwiseShiftsCombinedFilepath.isEmpty() ? TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( pairwiseShiftsCombinedFilepath ) ) : null;
+		final List< SerializablePairWiseStitchingResult > shiftsForCombinedChannels = !pairwiseShiftsCombinedFilepath.isEmpty() ? TileInfoJSONProvider.loadPairwiseShifts( dataProvider.getJsonReader( URI.create( pairwiseShiftsCombinedFilepath ) ) ) : null;
 		final String outputFolder = args[ args.length - 1 ];
 
 		if ( shifts[ 0 ].size() != shifts[ 1 ].size() || shifts[ 0 ].size() != shiftsForCombinedChannels.size() )

--- a/src/main/java/org/janelia/stitching/analysis/TracePairwiseShiftsForAllChannelsMulti.java
+++ b/src/main/java/org/janelia/stitching/analysis/TracePairwiseShiftsForAllChannelsMulti.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class TracePairwiseShiftsForAllChannelsMulti
 
 		final Map< Integer, TileInfo >[] channelsMap = new TreeMap[ 2 ];
 		for ( int i = 0; i < channelsMap.length; i++ )
-			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ i ] ) ) );
+			channelsMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ i ] ) ) ) );
 
 		// validate
 		for ( int i = 1; i < channelsMap.length; i++ )
@@ -36,15 +37,15 @@ public class TracePairwiseShiftsForAllChannelsMulti
 
 		final Map< Integer, TileInfo >[] channelsFinalMap = new TreeMap[ 2 ];
 		for ( int i = 0; i < channelsFinalMap.length; i++ )
-			channelsFinalMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 2 + i ] ) ) );
+			channelsFinalMap[ i ] = Utils.createTilesMap( TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 2 + i ] ) ) ) );
 
 
 		final List< SerializablePairWiseStitchingResult[] >[] shifts = new List[ 2 ];
 		for ( int i = 0; i < shifts.length; i++ )
-			shifts[ i ] = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( args[ 4 + i ] ) );
+			shifts[ i ] = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( args[ 4 + i ] ) ) );
 
 		final String pairwiseShiftsCombinedFilepath = args.length > 7 ? args[ args.length - 2 ] : "";
-		final List< SerializablePairWiseStitchingResult[] > shiftsForCombinedChannels = !pairwiseShiftsCombinedFilepath.isEmpty() ? TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( pairwiseShiftsCombinedFilepath ) ) : null;
+		final List< SerializablePairWiseStitchingResult[] > shiftsForCombinedChannels = !pairwiseShiftsCombinedFilepath.isEmpty() ? TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( URI.create( pairwiseShiftsCombinedFilepath ) ) ) : null;
 		final String outputFolder = args[ args.length - 1 ];
 
 		if ( shifts[ 0 ].size() != shifts[ 1 ].size() || shifts[ 0 ].size() != shiftsForCombinedChannels.size() )

--- a/src/main/java/org/janelia/stitching/analysis/TraceTimestamps.java
+++ b/src/main/java/org/janelia/stitching/analysis/TraceTimestamps.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.analysis;
 
 import java.io.PrintWriter;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
@@ -21,7 +22,7 @@ public class TraceTimestamps
 	{
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final List< Pair< TileInfo, Long > > timestamps = Utils.getTilesTimestamps( tiles );
 		final List< Pair< TileInfo, int[] > > coordinates = Utils.getTilesCoordinates( tiles );
 

--- a/src/main/java/org/janelia/stitching/experimental/BackgroundTilesFiltering.java
+++ b/src/main/java/org/janelia/stitching/experimental/BackgroundTilesFiltering.java
@@ -3,6 +3,7 @@ package org.janelia.stitching.experimental;
 import java.io.File;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -51,7 +52,7 @@ public class BackgroundTilesFiltering implements Serializable
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		this.input = input;
-		tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( input ) );
+		tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( input ) ) );
 		sparkContext = new JavaSparkContext( new SparkConf()
 				.setAppName( "BackgroundTilesFiltering" )
 				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )

--- a/src/main/java/org/janelia/stitching/experimental/ExportOverlaps.java
+++ b/src/main/java/org/janelia/stitching/experimental/ExportOverlaps.java
@@ -1,6 +1,7 @@
 package org.janelia.stitching.experimental;
 
 import java.io.File;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -151,7 +152,7 @@ public class ExportOverlaps
 		final int tileIndex = Integer.parseInt( args[ 1 ] );
 		System.out.println( "Processing tile " + tileIndex );
 
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( args[ 0 ] ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( args[ 0 ] ) ) );
 		final TreeMap< Integer, TileInfo > tilesMap = Utils.createTilesMap( tiles );
 
 		for ( final TileInfo tile : tiles )

--- a/src/main/java/org/janelia/stitching/experimental/HistogramsConversion.java
+++ b/src/main/java/org/janelia/stitching/experimental/HistogramsConversion.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -85,7 +86,7 @@ public class HistogramsConversion implements Serializable
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return;

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionHierarchical2D.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionHierarchical2D.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -157,7 +158,7 @@ public class IlluminationCorrectionHierarchical2D implements Serializable
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return;

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionHierarchical3D_Spark.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionHierarchical3D_Spark.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -159,7 +160,7 @@ public class IlluminationCorrectionHierarchical3D_Spark implements Serializable
 			);
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return;

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionLocal.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionLocal.java
@@ -10,6 +10,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -136,7 +137,7 @@ public class IlluminationCorrectionLocal
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 			N = tiles.length;
 		} catch (final IOException e) {
 			e.printStackTrace();

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionMap.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionMap.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -163,7 +164,7 @@ public class IlluminationCorrectionMap implements Serializable
 			);*/
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 			N = tiles.length;
 		} catch (final IOException e) {
 			e.printStackTrace();
@@ -687,7 +688,7 @@ public class IlluminationCorrectionMap implements Serializable
 		correctedTiles = task.collect().toArray( new TileInfo[0] );
 		try {
 			final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
-			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) ) );
 		} catch ( final IOException e ) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSlice.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSlice.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -166,7 +167,7 @@ public class IlluminationCorrectionSlice implements Serializable
 			);
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 			N = tiles.length;
 		} catch (final IOException e) {
 			e.printStackTrace();
@@ -1315,7 +1316,7 @@ public class IlluminationCorrectionSlice implements Serializable
 		correctedTiles = task.collect().toArray( new TileInfo[0] );
 		try {
 			final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
-			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) ) );
 		} catch ( final IOException e ) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSliceParallel.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSliceParallel.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -119,7 +120,7 @@ public class IlluminationCorrectionSliceParallel implements Serializable
 			);
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return;

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSliceParallelShrinked.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSliceParallelShrinked.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -118,7 +119,7 @@ public class IlluminationCorrectionSliceParallelShrinked implements Serializable
 			);
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 		} catch (final IOException e) {
 			e.printStackTrace();
 			return;

--- a/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSpark.java
+++ b/src/main/java/org/janelia/stitching/experimental/IlluminationCorrectionSpark.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -167,7 +168,7 @@ public class IlluminationCorrectionSpark implements Serializable
 			);
 
 		try {
-			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( inputFilepath ) );
+			tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( inputFilepath ) ) );
 			N = tiles.length;
 		} catch (final IOException e) {
 			e.printStackTrace();
@@ -1270,7 +1271,7 @@ public class IlluminationCorrectionSpark implements Serializable
 		correctedTiles = task.collect().toArray( new TileInfo[0] );
 		try {
 			final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
-			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) );
+			TileInfoJSONProvider.saveTilesConfiguration( correctedTiles, dataProvider.getJsonWriter( URI.create( Utils.addFilenameSuffix( inputFilepath, "_corrected" ) ) ) );
 		} catch ( final IOException e ) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/janelia/stitching/experimental/LoGTest.java
+++ b/src/main/java/org/janelia/stitching/experimental/LoGTest.java
@@ -1,5 +1,6 @@
 package org.janelia.stitching.experimental;
 
+import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
@@ -41,7 +42,7 @@ public class LoGTest {
 		final DataProvider dataProvider = DataProviderFactory.createFSDataProvider();
 
 		input = args[0];
-		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( input ) );
+		final TileInfo[] tiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( URI.create( input ) ) );
 		run_dog_nd( tiles[ 0 ], 0.5 );
 	}
 

--- a/src/test/java/org/janelia/flatfield/SerializableDataBlockWrapperTest.java
+++ b/src/test/java/org/janelia/flatfield/SerializableDataBlockWrapperTest.java
@@ -1,0 +1,78 @@
+package org.janelia.flatfield;
+
+import java.io.IOException;
+import java.util.Random;
+
+import org.janelia.saalfeldlab.n5.CompressionType;
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.N5;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.list.ListCursor;
+import net.imglib2.img.list.WrappedListImg;
+import net.imglib2.view.Views;
+
+public class SerializableDataBlockWrapperTest
+{
+	static private String testDirPath = System.getProperty("user.home") + "/tmp/n5-test";
+	static private final String datasetName = "/test/group/dataset";
+	static private final long[] dimensions = new long[]{100, 200, 300};
+	static private final int[] blockSize = new int[]{44, 33, 22};
+
+	static private Random rnd = new Random();
+
+	protected static N5Writer n5;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws IOException
+	{
+		n5 = N5.openFSWriter( testDirPath );
+	}
+
+	@AfterClass
+	public static void rampDownAfterClass() throws IOException
+	{
+		Assert.assertTrue( n5.remove() );
+	}
+
+	@Test
+	public void testSerializableTypeString() throws IOException {
+
+		for (final CompressionType compressionType : CompressionType.values()) {
+			System.out.println("Testing " + compressionType + " serializable type with String");
+			try {
+				n5.createDataset(datasetName, dimensions, blockSize, DataType.SERIALIZABLE, compressionType);
+				final SerializableDataBlockWrapper< String > dataBlockWrapper = new SerializableDataBlockWrapper<>( n5, datasetName, new long[]{0, 0, 0} );
+				final WrappedListImg< String > dataBlockWrapped = dataBlockWrapper.wrap();
+				final ListCursor< String > dataBlockCursor = dataBlockWrapped.cursor();
+				while ( dataBlockCursor.hasNext() )
+				{
+					final int len = rnd.nextInt(20);
+					final byte[] bytes = new byte[len];
+					rnd.nextBytes(bytes);
+					dataBlockCursor.fwd();
+					dataBlockCursor.set( new String( bytes ) );
+				}
+				dataBlockWrapper.save();
+
+				final SerializableDataBlockWrapper< String > loadedDataBlockWrapper = new SerializableDataBlockWrapper<>( n5, datasetName, new long[]{0, 0, 0} );
+				final RandomAccessibleInterval< String > loadedDataBlockWrapped = loadedDataBlockWrapper.wrap();
+				final Cursor< String > loadedDataBlockPlainCursor = Views.flatIterable( loadedDataBlockWrapped ).cursor();
+				final Cursor< String > dataBlockPlainCursor = Views.flatIterable( dataBlockWrapped ).cursor();
+				while ( dataBlockPlainCursor.hasNext() || loadedDataBlockPlainCursor.hasNext() )
+					Assert.assertEquals( dataBlockPlainCursor.next(), loadedDataBlockPlainCursor.next() );
+
+				Assert.assertTrue(n5.remove(datasetName));
+
+			} catch (final IOException e) {
+				Assert.fail(e.getMessage());
+			}
+		}
+	}
+}

--- a/src/test/java/org/janelia/stitching/TilesToN5Test.java
+++ b/src/test/java/org/janelia/stitching/TilesToN5Test.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Random;
 
 import org.apache.spark.SparkConf;
@@ -15,6 +16,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.CompressionType;
 import org.janelia.saalfeldlab.n5.N5;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.junit.Assert;
 import org.junit.Test;
 
 import ij.IJ;
@@ -75,13 +77,19 @@ public class TilesToN5Test
 				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
 			) )
 		{
-			TilesToN5Converter.convertTiffToN5(
+			final Map< String, TileInfo[] > newTiles = TilesToN5Converter.convertTiffToN5(
 					sparkContext,
+					n5Path,
 					() -> N5.openFSWriter( n5Path ),
 					Collections.singletonMap( datasetPath, tiles ),
 					blockSize,
 					CompressionType.GZIP
 				);
+
+			Assert.assertEquals( datasetPath, newTiles.keySet().iterator().next() );
+
+			final TileInfo newTile = newTiles.values().iterator().next()[ 0 ];
+			Assert.assertEquals( Paths.get( n5Path, datasetPath, impFilename ).toString(), newTile.getFilePath() );
 		}
 
 		System.out.println( "Loading N5 cell export from:" + Paths.get( n5Path, datasetPath ).toString() );

--- a/src/test/java/org/janelia/stitching/TilesToN5Test.java
+++ b/src/test/java/org/janelia/stitching/TilesToN5Test.java
@@ -1,0 +1,114 @@
+package org.janelia.stitching;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Random;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.janelia.saalfeldlab.n5.CompressionType;
+import org.janelia.saalfeldlab.n5.N5;
+import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.junit.Test;
+
+import ij.IJ;
+import ij.ImagePlus;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.exception.ImgLibException;
+import net.imglib2.img.imageplus.ImagePlusImg;
+import net.imglib2.img.imageplus.ImagePlusImgs;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+
+public class TilesToN5Test
+{
+	@Test
+	public void test() throws ImgLibException, IOException
+	{
+		final Random rnd = new Random();
+		final long[] dimensions = new long[ 3 ];
+		for ( int d = 0; d < dimensions.length; ++d )
+			dimensions[ d ] = rnd.nextInt( 700 ) + 1;
+
+		final int blockSize = rnd.nextInt( 100 ) + 30;
+
+		System.out.println( "Generating random image of size " + Arrays.toString( dimensions ) + ", block size set to " + blockSize );
+
+		final ImagePlusImg< UnsignedShortType, ? > img = ImagePlusImgs.unsignedShorts( dimensions );
+		final Cursor< UnsignedShortType > cursor = img.cursor();
+		while ( cursor.hasNext() )
+			cursor.next().set( ( int ) Math.round( ( rnd.nextGaussian() + 1.0 ) * 100 ) );
+
+		final ImagePlus imp = img.getImagePlus();
+		Utils.workaroundImagePlusNSlices( imp );
+
+		final Path tempDir = Files.createTempDirectory( "TilesToN5Test-" );
+		final String impFilename = "test-imp.tif";
+		final String impPath = tempDir.resolve( impFilename ).toString();
+
+		System.out.println( "Saving test image to: " + impPath );
+		IJ.saveAsTiff( imp, impPath );
+
+		final TileInfo tile = new TileInfo( dimensions.length );
+		tile.setIndex( 0 );
+		tile.setSize( dimensions );
+		tile.setPosition( new double[ dimensions.length ] );
+		tile.setFilePath( impPath );
+		tile.setType( ImageType.GRAY16 );
+		final TileInfo[] tiles = new TileInfo[] { tile };
+
+		final String n5Path = tempDir.resolve( "n5-test" ).toString();
+		final String datasetPath = "test-channel";
+
+		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
+				.setMaster( "local" )
+				.setAppName( "TilesToN5Test" )
+				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+			) )
+		{
+			TilesToN5Converter.convertTiffToN5(
+					sparkContext,
+					() -> N5.openFSWriter( n5Path ),
+					Collections.singletonMap( datasetPath, tiles ),
+					blockSize,
+					CompressionType.GZIP
+				);
+		}
+
+		System.out.println( "Loading N5 cell export from:" + Paths.get( n5Path, datasetPath ).toString() );
+
+		final RandomAccessibleInterval< UnsignedShortType > rai = N5Utils.open( N5.openFSReader( n5Path ), Paths.get( datasetPath, impFilename ).toString() );
+		final Cursor< UnsignedShortType > raiCursor = Views.iterable( rai ).localizingCursor();
+		final RandomAccess< UnsignedShortType > imgRandomAccess = img.randomAccess();
+		int pixelsProcessed = 0;
+		while ( raiCursor.hasNext() )
+		{
+			++pixelsProcessed;
+			raiCursor.fwd();
+			imgRandomAccess.setPosition( raiCursor );
+			if ( !raiCursor.get().valueEquals( imgRandomAccess.get() ) )
+			{
+				final long[] position = new long[ raiCursor.numDimensions() ];
+				raiCursor.localize( position );
+				fail( "pixel value differs at " + Arrays.toString( position ) );
+			}
+		}
+
+		if ( pixelsProcessed != Intervals.numElements( dimensions ) )
+			fail( "processed less pixels than contained in the image" );
+
+		System.out.println( "All checks passed, removing temp data..." );
+		N5.openFSWriter( tempDir.toString() ).remove();
+
+		System.out.println( "OK" );
+	}
+}

--- a/src/test/java/org/janelia/stitching/TilesToN5Test.java
+++ b/src/test/java/org/janelia/stitching/TilesToN5Test.java
@@ -16,8 +16,11 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.janelia.saalfeldlab.n5.CompressionType;
 import org.janelia.saalfeldlab.n5.N5;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
+import org.janelia.saalfeldlab.n5.s3.N5AmazonS3;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.amazonaws.services.s3.AmazonS3URI;
 
 import ij.IJ;
 import ij.ImagePlus;
@@ -34,7 +37,7 @@ import net.imglib2.view.Views;
 public class TilesToN5Test
 {
 	@Test
-	public void test() throws ImgLibException, IOException
+	public void testFS() throws ImgLibException, IOException
 	{
 		final Random rnd = new Random();
 		final long[] dimensions = new long[ 3 ];
@@ -95,6 +98,94 @@ public class TilesToN5Test
 		System.out.println( "Loading N5 cell export from:" + Paths.get( n5Path, datasetPath ).toString() );
 
 		final RandomAccessibleInterval< UnsignedShortType > rai = N5Utils.open( N5.openFSReader( n5Path ), Paths.get( datasetPath, impFilename ).toString() );
+		final Cursor< UnsignedShortType > raiCursor = Views.iterable( rai ).localizingCursor();
+		final RandomAccess< UnsignedShortType > imgRandomAccess = img.randomAccess();
+		int pixelsProcessed = 0;
+		while ( raiCursor.hasNext() )
+		{
+			++pixelsProcessed;
+			raiCursor.fwd();
+			imgRandomAccess.setPosition( raiCursor );
+			if ( !raiCursor.get().valueEquals( imgRandomAccess.get() ) )
+			{
+				final long[] position = new long[ raiCursor.numDimensions() ];
+				raiCursor.localize( position );
+				fail( "pixel value differs at " + Arrays.toString( position ) );
+			}
+		}
+
+		if ( pixelsProcessed != Intervals.numElements( dimensions ) )
+			fail( "processed less pixels than contained in the image" );
+
+		System.out.println( "All checks passed, removing temp data..." );
+		N5.openFSWriter( tempDir.toString() ).remove();
+
+		System.out.println( "OK" );
+	}
+
+//	@Test
+	public void testS3() throws ImgLibException, IOException
+	{
+		final Random rnd = new Random();
+		final long[] dimensions = new long[ 3 ];
+		for ( int d = 0; d < dimensions.length; ++d )
+			dimensions[ d ] = rnd.nextInt( 700 ) + 1;
+
+		final int blockSize = rnd.nextInt( 100 ) + 30;
+
+		System.out.println( "Generating random image of size " + Arrays.toString( dimensions ) + ", block size set to " + blockSize );
+
+		final ImagePlusImg< UnsignedShortType, ? > img = ImagePlusImgs.unsignedShorts( dimensions );
+		final Cursor< UnsignedShortType > cursor = img.cursor();
+		while ( cursor.hasNext() )
+			cursor.next().set( ( int ) Math.round( ( rnd.nextGaussian() + 1.0 ) * 100 ) );
+
+		final ImagePlus imp = img.getImagePlus();
+		Utils.workaroundImagePlusNSlices( imp );
+
+		final Path tempDir = Files.createTempDirectory( "TilesToN5Test-" );
+		final String impFilename = "test-imp.tif";
+		final String impPath = tempDir.resolve( impFilename ).toString();
+
+		System.out.println( "Saving test image to: " + impPath );
+		IJ.saveAsTiff( imp, impPath );
+
+		final TileInfo tile = new TileInfo( dimensions.length );
+		tile.setIndex( 0 );
+		tile.setSize( dimensions );
+		tile.setPosition( new double[ dimensions.length ] );
+		tile.setFilePath( impPath );
+		tile.setType( ImageType.GRAY16 );
+		final TileInfo[] tiles = new TileInfo[] { tile };
+
+		final String n5Bucket = "test-bucket-n5";
+		final String s3Link = new AmazonS3URI( "s3://" + n5Bucket + "/" ).toString();
+		final String datasetPath = "test-channel";
+
+		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
+				.setMaster( "local" )
+				.setAppName( "TilesToN5Test" )
+				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+			) )
+		{
+			final Map< String, TileInfo[] > newTiles = TilesToN5Converter.convertTiffToN5(
+					sparkContext,
+					s3Link,
+					() -> N5AmazonS3.openS3Writer( n5Bucket ),
+					Collections.singletonMap( datasetPath, tiles ),
+					blockSize,
+					CompressionType.GZIP
+				);
+
+			Assert.assertEquals( datasetPath, newTiles.keySet().iterator().next() );
+
+			final TileInfo newTile = newTiles.values().iterator().next()[ 0 ];
+			Assert.assertEquals( Paths.get( s3Link, datasetPath, impFilename ).toString(), newTile.getFilePath() );
+		}
+
+		System.out.println( "Loading N5 cell export from:" + Paths.get( s3Link, datasetPath ).toString() );
+
+		final RandomAccessibleInterval< UnsignedShortType > rai = N5Utils.open( N5AmazonS3.openS3Reader( n5Bucket ), Paths.get( datasetPath, impFilename ).toString() );
 		final Cursor< UnsignedShortType > raiCursor = Views.iterable( rai ).localizingCursor();
 		final RandomAccess< UnsignedShortType > imgRandomAccess = img.randomAccess();
 		int pixelsProcessed = 0;


### PR DESCRIPTION
* Allows to run the stitching pipeline on Amazon Web Services / Google Cloud Platform
* Provides a tool that converts and uploads tiles to the corresponding cloud storage as N5 datasets
* Changes the histograms format in the flatfield correction pipeline to N5 and populates them block-wise instead of slice-wise