### PR TITLE
Deconvolution on Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>
-			<artifactId>imagej</artifactId>
+			<artifactId>imagej-ops</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,10 @@
 									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
 									<resource>reference.conf</resource>
 								</transformer>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+									<resource>META-INF/json/org.scijava.plugin.Plugin</resource>
+								</transformer>
 							</transformers>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,10 @@
 			<artifactId>imglib2-cache</artifactId>
 			<version>1.0.0-beta-7</version>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/net/imglib2/converter/ClampingConverter.java
+++ b/src/main/java/net/imglib2/converter/ClampingConverter.java
@@ -1,0 +1,42 @@
+package net.imglib2.converter;
+
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+
+public class ClampingConverter< I extends NativeType< I > & RealType< I >, O extends NativeType< O > & RealType< O > > implements Converter< I, O >
+{
+	private final double minInputValue, maxInputValue;
+	private final double minOutputValue, maxOutputValue;
+	private final double inputValueRange, outputValueRange;
+
+	public ClampingConverter(
+			final double minInputValue, final double maxInputValue,
+			final double minOutputValue, final double maxOutputValue )
+	{
+		this.minInputValue = minInputValue; this.maxInputValue = maxInputValue;
+		this.minOutputValue = minOutputValue; this.maxOutputValue = maxOutputValue;
+
+		inputValueRange = maxInputValue - minInputValue;
+		outputValueRange = maxOutputValue - minOutputValue;
+	}
+
+	@Override
+	public void convert( final I input, final O output )
+	{
+		final double inputValue = input.getRealDouble();
+		if ( inputValue <= minInputValue )
+		{
+			output.setReal( minOutputValue );
+		}
+		else if ( inputValue >= maxInputValue )
+		{
+			output.setReal( maxOutputValue );
+		}
+		else
+		{
+			final double normalizedInputValue = ( inputValue - minInputValue ) / inputValueRange;
+			final double realOutputValue = normalizedInputValue * outputValueRange + minOutputValue;
+			output.setReal( realOutputValue );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/converter/RealConverter.java
+++ b/src/main/java/net/imglib2/converter/RealConverter.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.converter;
+
+import net.imglib2.type.numeric.RealType;
+
+public class RealConverter< I extends RealType< I >, O extends RealType< O > > implements Converter< I, O >
+{
+	@Override
+	public void convert( final I input, final O output )
+	{
+		output.setReal( input.getRealDouble() );
+		output.setImaginary( input.getImaginaryDouble() );
+	}
+}

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -204,6 +204,13 @@ public class DeconvolutionSpark
 					final RandomAccessibleInterval< FloatType > sourceImgNoBackground = subtractBackground( sourceImgFloat, backgroundValue );
 					final RandomAccessibleInterval< FloatType > psfImgNoBackground = subtractBackground( psfImgFloat, backgroundValue );
 
+					// normalize the PSF
+					double psfSum = 0;
+					for ( final FloatType val : Views.iterable( psfImgNoBackground ) )
+						psfSum += val.get();
+					for ( final FloatType val : Views.iterable( psfImgNoBackground ) )
+						val.set( ( float ) ( val.get() / psfSum ) );
+
 					// run decon
 					final RandomAccessibleInterval< FloatType > deconImg;
 					try ( final OpServiceContainer opServiceContainer = new OpServiceContainer() )

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -61,6 +61,10 @@ public class DeconvolutionSpark
 				usage = "Number of iterations to perform for the deconvolution algorithm.")
 		private int numIterations = 10;
 
+		@Option(name = "-r", aliases = { "--regularization" }, required = false,
+				usage = "Regularization coefficient for the total variation constraint in the deconvolution algorithm.")
+		private float regularization = 0.01f;
+
 		@Option(name = "-b", aliases = { "--backgroundValue" }, required = false,
 				usage = "Background value of the data for each channel. If omitted, the pivot value estimated in the Flatfield Correction step will be used.")
 		private Double backgroundValue = null;
@@ -210,10 +214,11 @@ public class DeconvolutionSpark
 					final RandomAccessibleInterval< FloatType > deconImg;
 					try ( final OpServiceContainer opServiceContainer = new OpServiceContainer() )
 					{
-						deconImg = opServiceContainer.ops().deconvolve().richardsonLucy(
+						deconImg = opServiceContainer.ops().deconvolve().richardsonLucyTV(
 								sourceImgNoBackground,
 								psfImgNoBackground,
-								parsedArgs.numIterations
+								parsedArgs.numIterations,
+								parsedArgs.regularization
 							);
 					}
 

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -84,10 +84,14 @@ public class DeconvolutionSpark
 			if ( inputChannelsPaths.size() != psfPaths.size() )
 				throw new IllegalArgumentException( "Number of input channels should match the number of PSFs" );
 
-			// make sure that inputChannelsPaths contains absolute file paths if running on a traditional filesystem
+			// make sure that input paths are absolute file paths if running on a traditional filesystem
 			for ( int i = 0; i < inputChannelsPaths.size(); ++i )
 				if ( !CloudURI.isCloudURI( inputChannelsPaths.get( i ) ) )
 					inputChannelsPaths.set( i, Paths.get( inputChannelsPaths.get( i ) ).toAbsolutePath().toString() );
+
+			for ( int i = 0; i < psfPaths.size(); ++i )
+				if ( !CloudURI.isCloudURI( psfPaths.get( i ) ) )
+					psfPaths.set( i, Paths.get( psfPaths.get( i ) ).toAbsolutePath().toString() );
 		}
 	}
 

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -37,9 +37,7 @@ import net.imglib2.img.imageplus.ImagePlusImgs;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Pair;
 import net.imglib2.util.Util;
-import net.imglib2.util.ValuePair;
 import net.imglib2.view.RandomAccessiblePairNullable;
 import net.imglib2.view.Views;
 import scala.Tuple2;
@@ -325,6 +323,7 @@ public class DeconvolutionSpark
 								globalDeconMinMaxValues._1(), globalDeconMinMaxValues._2(),
 								inputImageType.getType().getMinValue(), inputImageType.getType().getMaxValue()
 							);
+						@SuppressWarnings( "unchecked" )
 						final RandomAccessibleInterval< T > rescaledDeconTileImg = Converters.convert( deconTileImg, rescalingConverter, ( T ) inputImageType.getType() );
 						final ImagePlus rescaledDeconImp = Utils.copyToImagePlus( rescaledDeconTileImg );
 
@@ -377,17 +376,6 @@ public class DeconvolutionSpark
 		while ( imgCursor.hasNext() || retCursor.hasNext() )
 			retCursor.next().setReal( Math.max( imgCursor.next().getRealDouble() - backgroundValue, 0 ) );
 		return ret;
-	}
-
-	private static < T extends NativeType< T > & RealType< T > > Pair< Double, Double > getMinMax( final RandomAccessibleInterval< T > img )
-	{
-		double min = Double.POSITIVE_INFINITY, max = Double.NEGATIVE_INFINITY;
-		for ( final T val : Views.iterable( img ) )
-		{
-			min = Math.min( val.getRealDouble(), min );
-			max = Math.max( val.getRealDouble(), max );
-		}
-		return new ValuePair<>( min, max );
 	}
 
 	private static Map< Integer, Map< Integer, TileInfo > > groupTilesIntoChannels( final Collection< Tuple2< TileInfo, Integer > > tilesAndChannelIndices )

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -61,10 +61,6 @@ public class DeconvolutionSpark
 				usage = "Number of iterations to perform for the deconvolution algorithm.")
 		private int numIterations = 10;
 
-		@Option(name = "-r", aliases = { "--regularization" }, required = false,
-				usage = "Regularization coefficient for the total variation constraint in the deconvolution algorithm.")
-		private float regularization = 0.01f;
-
 		@Option(name = "-b", aliases = { "--backgroundValue" }, required = false,
 				usage = "Background value of the data for each channel. If omitted, the pivot value estimated in the Flatfield Correction step will be used.")
 		private Double backgroundValue = null;
@@ -212,15 +208,7 @@ public class DeconvolutionSpark
 					final RandomAccessibleInterval< FloatType > deconImg;
 					try ( final OpServiceContainer opServiceContainer = new OpServiceContainer() )
 					{
-						deconImg = opServiceContainer.ops().deconvolve().richardsonLucyTV(
-								sourceImgNoBackground,
-								psfImgNoBackground,
-								null, null, null, null, null,
-								parsedArgs.numIterations,
-								true,	// non-circulant mode to prevent ringing artifacts at the edges
-								true,	// accelerated mode
-								parsedArgs.regularization
-							);
+						deconImg = opServiceContainer.ops().deconvolve().richardsonLucy( sourceImgNoBackground, psfImgNoBackground, parsedArgs.numIterations );
 					}
 
 					// rescale data back to 16-bit (use the original range)

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -152,6 +152,7 @@ public class DeconvolutionSpark
 		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
 				.setAppName( "DeconvolutionSpark" )
 				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+				.set( "spark.speculation", "true" ) // will restart tasks that run for too long (if decon hangs which may happen occasionally)
 			) )
 		{
 			// initialize input tiles

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -1,0 +1,246 @@
+package org.janelia.stitching;
+
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.janelia.dataaccess.CloudURI;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderFactory;
+import org.janelia.dataaccess.DataProviderType;
+import org.janelia.dataaccess.PathResolver;
+import org.janelia.flatfield.FlatfieldCorrectedRandomAccessible;
+import org.janelia.flatfield.FlatfieldCorrection;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import ij.ImagePlus;
+import net.imagej.ImageJ;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.ClampingConverter;
+import net.imglib2.converter.Converters;
+import net.imglib2.converter.RealConverter;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.img.imageplus.ImagePlusImgs;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Pair;
+import net.imglib2.util.Util;
+import net.imglib2.util.ValuePair;
+import net.imglib2.view.RandomAccessiblePairNullable;
+import net.imglib2.view.Views;
+import scala.Tuple2;
+
+public class DeconvolutionSpark
+{
+	private static class DeconvolutionCmdArgs implements Serializable
+	{
+		private static final long serialVersionUID = 215043103837732209L;
+
+		@Option(name = "-i", aliases = { "--inputConfigurationPath" }, required = true,
+				usage = "Path to an input tile configuration file. Multiple configurations (channels) can be passed at once.")
+		private List< String > inputChannelsPaths;
+
+		@Option(name = "-p", aliases = { "--psfPath" }, required = true,
+				usage = "Path to the point-spread function images. In case of multiple input channels, their corresponding PSFs must be passed in the same order.")
+		private List< String > psfPaths;
+
+		@Option(name = "-n", aliases = { "--numIterations" }, required = false,
+				usage = "Number of iterations to perform for the deconvolution algorithm.")
+		private int numIterations = 10;
+
+		@Option(name = "-b", aliases = { "--backgroundValue" }, required = false,
+				usage = "Background value of the data for each channel. If omitted, the pivot value estimated in the Flatfield Correction step will be used.")
+		private Double backgroundValue = null;
+
+		private boolean parsedSuccessfully = false;
+
+		public DeconvolutionCmdArgs( final String... args ) throws IllegalArgumentException
+		{
+			final CmdLineParser parser = new CmdLineParser( this );
+			try
+			{
+				parser.parseArgument( args );
+				parsedSuccessfully = true;
+			}
+			catch ( final CmdLineException e )
+			{
+				System.err.println( e.getMessage() );
+				parser.printUsage( System.err );
+			}
+
+			if ( inputChannelsPaths.size() != psfPaths.size() )
+				throw new IllegalArgumentException( "Number of input channels should match the number of PSFs" );
+
+			// make sure that inputChannelsPaths contains absolute file paths if running on a traditional filesystem
+			for ( int i = 0; i < inputChannelsPaths.size(); ++i )
+				if ( !CloudURI.isCloudURI( inputChannelsPaths.get( i ) ) )
+					inputChannelsPaths.set( i, Paths.get( inputChannelsPaths.get( i ) ).toAbsolutePath().toString() );
+		}
+	}
+
+	public static < T extends NativeType< T > & RealType< T >, U extends NativeType< U > & RealType< U > > void main( final String[] args ) throws Exception
+	{
+		final DeconvolutionCmdArgs parsedArgs = new DeconvolutionCmdArgs( args );
+		if ( !parsedArgs.parsedSuccessfully )
+			System.exit( 1 );
+
+		final DataProviderType dataProviderType = DataProviderFactory.detectType( parsedArgs.inputChannelsPaths.iterator().next() );
+		final DataProvider dataProvider = DataProviderFactory.create( dataProviderType );
+
+		final String outputImagesPath = PathResolver.get( PathResolver.getParent( parsedArgs.inputChannelsPaths.iterator().next() ), "decon-tiles" );
+		dataProvider.createFolder( outputImagesPath );
+
+		final Map< Integer, Map< Integer, TileInfo > > channelDeconTilesMap = new TreeMap<>();
+
+		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
+				.setAppName( "DeconvolutionSpark" )
+				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
+			) )
+		{
+			// initialize input tiles
+			final List< Tuple2< TileInfo, Integer > > tilesAndChannelIndices = new ArrayList<>();
+			for ( int ch = 0; ch < parsedArgs.inputChannelsPaths.size(); ++ch )
+				for ( final TileInfo tile : dataProvider.loadTiles( parsedArgs.inputChannelsPaths.get( ch ) ) )
+					tilesAndChannelIndices.add( new Tuple2<>( tile, ch ) );
+
+			// initialize background value for each channel
+			final List< Double > channelBackgroundValues = new ArrayList<>();
+			for ( final String channelPath : parsedArgs.inputChannelsPaths )
+				channelBackgroundValues.add( parsedArgs.backgroundValue != null ? parsedArgs.backgroundValue : FlatfieldCorrection.getPivotValue( dataProvider, channelPath ) );
+
+			// initialize flatfields for each channel
+			final List< RandomAccessiblePairNullable< U, U > > channelFlatfields = new ArrayList<>();
+			for ( final String channelPath : parsedArgs.inputChannelsPaths )
+				channelFlatfields.add( FlatfieldCorrection.loadCorrectionImages( dataProvider, channelPath, tilesAndChannelIndices.iterator().next()._1().numDimensions() ) );
+			final Broadcast< List< RandomAccessiblePairNullable< U, U > > > broadcastedChannelFlatfields = sparkContext.broadcast( channelFlatfields );
+
+			final List< Tuple2< TileInfo, Integer > > deconTilesAndChannelIndices = sparkContext.parallelize( tilesAndChannelIndices ).map( tileAndChannelIndex->
+				{
+					final TileInfo tile = tileAndChannelIndex._1();
+					final int channelIndex = tileAndChannelIndex._2();
+
+					final DataProvider localDataProvider = DataProviderFactory.create( dataProviderType );
+
+					// load tile image
+					final RandomAccessibleInterval< T > tileImg = TileLoader.loadTile( tile, localDataProvider );
+
+					// load PSF image
+					final ImagePlus psfImp = localDataProvider.loadImage( parsedArgs.psfPaths.get( channelIndex ) );
+					Utils.workaroundImagePlusNSlices( psfImp );
+					final RandomAccessibleInterval< T > psfImg = ImagePlusImgs.from( psfImp );
+
+					// convert to float type for the deconvolution to work properly
+					final RandomAccessibleInterval< FloatType > tileImgFloat = Converters.convert( tileImg, new RealConverter<>(), new FloatType() );
+					final RandomAccessibleInterval< FloatType > psfImgFloat = Converters.convert( psfImg, new RealConverter<>(), new FloatType() );
+
+					// apply flatfield correction
+					final RandomAccessibleInterval< FloatType > sourceImgFloat;
+					final RandomAccessiblePairNullable< U, U > flatfield = broadcastedChannelFlatfields.value().get( channelIndex );
+					if ( flatfield != null )
+					{
+						final FlatfieldCorrectedRandomAccessible< FloatType, U > flatfieldCorrectedTileImg = new FlatfieldCorrectedRandomAccessible<>( tileImgFloat, flatfield.toRandomAccessiblePair() );
+						final RandomAccessibleInterval< U > correctedImg = Views.interval( flatfieldCorrectedTileImg, tileImgFloat );
+						sourceImgFloat = Converters.convert( correctedImg, new RealConverter<>(), new FloatType() );
+					}
+					else
+					{
+						sourceImgFloat = tileImgFloat;
+					}
+
+					// subtract background
+					final double backgroundValue = channelBackgroundValues.get( channelIndex );
+					final RandomAccessibleInterval< FloatType > sourceImgNoBackground = subtractBackground( sourceImgFloat, backgroundValue );
+					final RandomAccessibleInterval< FloatType > psfImgNoBackground = subtractBackground( psfImgFloat, backgroundValue );
+
+					// TODO: edgetaper
+
+					// run decon
+					final RandomAccessibleInterval< FloatType > deconImg = new ImageJ().op().deconvolve().richardsonLucy(
+							sourceImgNoBackground,
+							psfImgNoBackground,
+							parsedArgs.numIterations
+						);
+
+					// rescale data back to 16-bit (use the original range)
+					final Pair< Double, Double > inputDataMinMax = getMinMax( tileImg );
+					final Pair< Double, Double > outputDataMinMax = getMinMax( deconImg );
+					final ClampingConverter< FloatType, T > deconConverter = new ClampingConverter<>(
+							outputDataMinMax.getA(), outputDataMinMax.getB(),
+							inputDataMinMax.getA(), inputDataMinMax.getB()
+						);
+					final RandomAccessibleInterval< T > convertedDeconImg = Converters.convert( deconImg, deconConverter, Util.getTypeFromInterval( tileImg ) );
+
+					// save resulting decon tile
+					final ImagePlus deconImp = Utils.copyToImagePlus( convertedDeconImg );
+					final String deconTilePath = PathResolver.get( outputImagesPath, Utils.addFilenameSuffix( PathResolver.getFileName( tile.getFilePath() ), "-decon" ) );
+					localDataProvider.saveImage( deconImp, deconTilePath );
+
+					// build resulting decon tile metadata
+					final TileInfo deconTile = tile.clone();
+					deconTile.setFilePath( deconTilePath );
+
+					return new Tuple2<>( deconTile, tileAndChannelIndex._2() );
+				}
+			).collect();
+
+			broadcastedChannelFlatfields.destroy();
+
+			// group decon tiles into channels
+			for ( final Tuple2< TileInfo, Integer > deconTileAndChannelIndex : deconTilesAndChannelIndices )
+			{
+				final TileInfo deconTile = deconTileAndChannelIndex._1();
+				final int channelIndex = deconTileAndChannelIndex._2();
+
+				if ( !channelDeconTilesMap.containsKey( channelIndex ) )
+					channelDeconTilesMap.put( channelIndex, new TreeMap<>() );
+
+				channelDeconTilesMap.get( channelIndex ).put( deconTile.getIndex(), deconTile );
+			}
+		}
+
+		// save resulting decon tiles metadata
+		for ( final Entry< Integer, Map< Integer, TileInfo > > channelDeconTiles : channelDeconTilesMap.entrySet() )
+		{
+			dataProvider.saveTiles(
+					channelDeconTiles.getValue().values().toArray( new TileInfo[ 0 ] ),
+					Utils.addFilenameSuffix( parsedArgs.inputChannelsPaths.get( channelDeconTiles.getKey() ), "-decon" )
+				);
+		}
+
+		System.out.println( "Done" );
+	}
+
+	private static < T extends NativeType< T > & RealType< T > > RandomAccessibleInterval< T > subtractBackground(
+			final RandomAccessibleInterval< T > img,
+			final double backgroundValue )
+	{
+		final RandomAccessibleInterval< T > ret = new ArrayImgFactory< T >().create( img, Util.getTypeFromInterval( img ) );
+		final Cursor< T > imgCursor = Views.flatIterable( img ).cursor();
+		final Cursor< T > retCursor = Views.flatIterable( ret ).cursor();
+		while ( imgCursor.hasNext() || retCursor.hasNext() )
+			retCursor.next().setReal( Math.max( imgCursor.next().getRealDouble() - backgroundValue, 0 ) );
+		return ret;
+	}
+
+	private static < T extends NativeType< T > & RealType< T > > Pair< Double, Double > getMinMax( final RandomAccessibleInterval< T > img )
+	{
+		double min = Double.POSITIVE_INFINITY, max = Double.NEGATIVE_INFINITY;
+		for ( final T val : Views.iterable( img ) )
+		{
+			min = Math.min( val.getRealDouble(), min );
+			max = Math.max( val.getRealDouble(), max );
+		}
+		return new ValuePair<>( min, max );
+	}
+}

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -208,8 +208,6 @@ public class DeconvolutionSpark
 					final RandomAccessibleInterval< FloatType > sourceImgNoBackground = subtractBackground( sourceImgFloat, backgroundValue );
 					final RandomAccessibleInterval< FloatType > psfImgNoBackground = subtractBackground( psfImgFloat, backgroundValue );
 
-					// TODO: edgetaper
-
 					// run decon
 					final RandomAccessibleInterval< FloatType > deconImg;
 					try ( final OpServiceContainer opServiceContainer = new OpServiceContainer() )
@@ -217,7 +215,10 @@ public class DeconvolutionSpark
 						deconImg = opServiceContainer.ops().deconvolve().richardsonLucyTV(
 								sourceImgNoBackground,
 								psfImgNoBackground,
+								null, null, null, null, null,
 								parsedArgs.numIterations,
+								true,	// non-circulant mode to prevent ringing artifacts at the edges
+								true,	// accelerated mode
 								parsedArgs.regularization
 							);
 					}

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -146,7 +146,6 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 
 			final String absoluteChannelPath = job.getArgs().inputTileConfigurations().get( channel );
 			final String absoluteChannelPathNoFinal = Utils.removeFilenameSuffix( absoluteChannelPath, "-final" ); // adjust the path in order to use original flatfields
-			final String absoluteChannelPathNoFinalNoExt = absoluteChannelPathNoFinal.lastIndexOf( '.' ) != -1 ? absoluteChannelPathNoFinal.substring( 0, absoluteChannelPathNoFinal.lastIndexOf( '.' ) ) : absoluteChannelPathNoFinal;
 
 			n5.createGroup( N5ExportMetadata.getChannelGroupPath( channel ) );
 
@@ -160,7 +159,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 			// use it as a folder with the input file's name
 			final RandomAccessiblePairNullable< U, U >  flatfieldCorrection = FlatfieldCorrection.loadCorrectionImages(
 					dataProvider,
-					absoluteChannelPathNoFinalNoExt,
+					absoluteChannelPathNoFinal,
 					job.getDimensionality()
 				);
 			if ( flatfieldCorrection != null )

--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -377,10 +377,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 		System.out.println( "Broadcasting flatfield correction images" );
 		final List< RandomAccessiblePairNullable< U, U > > flatfieldCorrectionForChannels = new ArrayList<>();
 		for ( final String channelPath : job.getArgs().inputTileConfigurations() )
-		{
-			final String channelPathNoExt = channelPath.lastIndexOf( '.' ) != -1 ? channelPath.substring( 0, channelPath.lastIndexOf( '.' ) ) : channelPath;
-			flatfieldCorrectionForChannels.add( FlatfieldCorrection.loadCorrectionImages( dataProvider, channelPathNoExt, job.getDimensionality() ) );
-		}
+			flatfieldCorrectionForChannels.add( FlatfieldCorrection.loadCorrectionImages( dataProvider, channelPath, job.getDimensionality() ) );
 		final Broadcast< List< RandomAccessiblePairNullable< U, U > > > broadcastedFlatfieldCorrectionForChannels = sparkContext.broadcast( flatfieldCorrectionForChannels );
 
 		final List< Map< Integer, TileInfo > > tileChannelMappingByIndex = new ArrayList<>();

--- a/src/main/java/org/janelia/stitching/Utils.java
+++ b/src/main/java/org/janelia/stitching/Utils.java
@@ -15,13 +15,21 @@ import org.janelia.util.Conversions;
 import ij.IJ;
 import ij.ImagePlus;
 import mpicbg.stitching.ImageCollectionElement;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.exception.ImgLibException;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.img.imageplus.ImagePlusImg;
+import net.imglib2.img.imageplus.ImagePlusImgFactory;
+import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Intervals;
 import net.imglib2.util.Pair;
+import net.imglib2.util.Util;
 import net.imglib2.util.ValuePair;
+import net.imglib2.view.Views;
 
 /**
  * Provides some useful methods for working with file paths
@@ -74,6 +82,18 @@ public class Utils {
 		return createElement( null, tile );
 	}
 
+	public static < T extends NativeType< T > & RealType< T > > ImagePlus copyToImagePlus( final RandomAccessibleInterval< T > img ) throws ImgLibException
+	{
+		final ImagePlusImg< T, ? > imagePlusImg = new ImagePlusImgFactory< T >().create( Intervals.dimensionsAsLongArray( img ), Util.getTypeFromInterval( img ) );
+		final Cursor< T > imgCursor = Views.flatIterable( img ).cursor();
+		final Cursor< T > imagePlusImgCursor = Views.flatIterable( imagePlusImg ).cursor();
+		while ( imagePlusImgCursor.hasNext() || imgCursor.hasNext() )
+			imagePlusImgCursor.next().set( imgCursor.next() );
+		final ImagePlus imp = imagePlusImg.getImagePlus();
+		workaroundImagePlusNSlices( imp );
+		return imp;
+	}
+
 	public static void workaroundImagePlusNSlices( final ImagePlus imp )
 	{
 		final int[] possible3rdDim = new int[] { imp.getNChannels(), imp.getNSlices(), imp.getNFrames() };
@@ -81,6 +101,7 @@ public class Utils {
 		if ( possible3rdDim[ 0 ] * possible3rdDim[ 1 ] == 1 )
 			imp.setDimensions( 1, possible3rdDim[ 2 ], 1 );
 	}
+
 	public static int[] getImagePlusDimensions( final ImagePlus imp )
 	{
 		final int[] dim3 = new int[] { imp.getNChannels(), imp.getNSlices(), imp.getNFrames() };

--- a/startup-scripts/spark-janelia/deconvolution.py
+++ b/startup-scripts/spark-janelia/deconvolution.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+
+sys.dont_write_bytecode = True
+curr_script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(curr_script_dir))
+from jar_path_util import get_jar_path
+bin_path = get_jar_path()
+
+flintstone_relpath = os.path.join('flintstone', 'flintstone.sh')
+flintstone_path = os.path.join(curr_script_dir, flintstone_relpath)
+
+os.environ['SPARK_VERSION'] = 'test'
+os.environ['N_DRIVER_THREADS'] = '4'
+os.environ['TERMINATE'] = '1'
+
+nodes = int(sys.argv[1])
+
+subprocess.call([flintstone_path, str(nodes), bin_path, 'org.janelia.stitching.DeconvolutionSpark'] + sys.argv[2:])

--- a/startup-scripts/spark-local/deconvolution.py
+++ b/startup-scripts/spark-local/deconvolution.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import subprocess
+
+sys.dont_write_bytecode = True
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from jar_path_util import get_jar_path
+bin_path = get_jar_path()
+
+subprocess.call(['java', '-Dspark.master=local[*]', '-cp', bin_path, 'org.janelia.stitching.DeconvolutionSpark'] + sys.argv[1:])


### PR DESCRIPTION
Adds a Spark job for running Richardson-Lucy deconvolution algorithm on input tile images with a known point-spread function image.
* the flatfield correction is applied to the input tile
* the background value is subtracted from both the input image and the PSF to retain only true signal for deconvolution (if not provided as a cmd line arg, the "pivot" value is used that was estimated in the flatfield step)
* after the deconvolution, the intensity values in the resulting image are rescaled back to the original intensity range of the input data