### PR TITLE
Add option to use only one channel for stitching

### DIFF
--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -11,6 +12,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -71,7 +74,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 	{
 		final DataProvider dataProvider = job.getDataProvider();
 
-		final List< TilePair > overlappingTiles = TileOperations.findOverlappingTiles( job.getTiles( 0 ) );
+		final List< TilePair > overlappingTiles = TileOperations.findOverlappingTiles( job.getTiles( job.getMainChannelIndex() ) );
 		System.out.println( "Overlapping pairs count = " + overlappingTiles.size() );
 
 		// Remove pairs with small overlap area if only adjacent pairs are requested
@@ -91,8 +94,8 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 			for ( int iteration = 0; ; ++iteration )
 			{
 				// check if number of stitched tiles has increased compared to the previous iteration
-				final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( 0 ) );
-				final String filename = PathResolver.getFileName( job.getArgs().inputTileConfigurations().get( 0 ) );
+				final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) );
+				final String filename = PathResolver.getFileName( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) );
 				final String iterationDirname = "iter" + iteration;
 				final String stitchedTilesFilepath = PathResolver.get( basePath, iterationDirname, Utils.addFilenameSuffix( filename, "-stitched" ) );
 
@@ -108,7 +111,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 				}
 
 				// check if number of stitched tiles has increased compared to the previous iteration
-				final TileInfo[] stageTiles = job.getTiles( 0 );
+				final TileInfo[] stageTiles = job.getTiles( job.getMainChannelIndex() );
 				final TileInfo[] stitchedTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( stitchedTilesFilepath ) );
 
 				// TODO: test and keep if works or remove (currently generates worse solutions)
@@ -173,7 +176,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 			final String finalTilesFilepath = PathResolver.get( basePath, Utils.addFilenameSuffix( filename, "-final" ) );
 			dataProvider.copyFile( stitchedTilesFilepath, finalTilesFilepath );
 
-			if ( channel == 0 )
+			if ( channel == job.getMainChannelIndex() )
 				dataProvider.copyFile(
 						PathResolver.get( basePath, iterationDirname, "optimizer.txt" ),
 						PathResolver.get( basePath, "optimizer-final.txt" )
@@ -185,7 +188,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 	{
 		final DataProvider dataProvider = job.getDataProvider();
 
-		final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( 0 ) );
+		final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) );
 		final String iterationDirname = "iter" + iteration;
 		final String previousIterationDirname = iteration == 0 ? null : "iter" + ( iteration - 1 );
 		final String pairwiseFilename = "pairwise.json";
@@ -322,7 +325,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 			final String statsTileConfigurationPath = iteration == 0 ? null : PathResolver.get(
 					basePath,
 					previousIterationDirname,
-					Utils.addFilenameSuffix( PathResolver.getFileName( job.getArgs().inputTileConfigurations().get( 0 ) ), "-stitched" )
+					Utils.addFilenameSuffix( PathResolver.getFileName( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) ), "-stitched" )
 				);
 
 			// Initiate the computation
@@ -355,8 +358,8 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 			try
 			{
 				final TileInfo[] statsTiles = TileInfoJSONProvider.loadTilesConfiguration( dataProvider.getJsonReader( statsTileConfigurationPath ) );
-				System.out.println( "-- Creating search radius estimator using " + job.getTiles( 0 ).length + " stage tiles and " + statsTiles.length + " stitched tiles --" );
-				searchRadiusEstimator = new TileSearchRadiusEstimator( job.getTiles( 0 ), statsTiles );
+				System.out.println( "-- Creating search radius estimator using " + job.getTiles( job.getMainChannelIndex() ).length + " stage tiles and " + statsTiles.length + " stitched tiles --" );
+				searchRadiusEstimator = new TileSearchRadiusEstimator( job.getTiles( job.getMainChannelIndex() ), statsTiles );
 				System.out.println( "-- Created search radius estimator. Estimation window size (neighborhood): " + Arrays.toString( Intervals.dimensionsAsIntArray( searchRadiusEstimator.getEstimationWindowSize() ) ) + " --" );
 			}
 			catch ( final IOException e )
@@ -427,7 +430,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 						{
 							notEnoughNeighborsWithinConfidenceIntervalPairsCount.add( 1 );
 
-//								System.out.println( "Found " + searchRadiusEstimationWindow.getUsedPointsIndexes().size() + " neighbors within the search window but we require " + numNearestNeighbors + " nearest neighbors, perform a K-nearest neighbor search instead..." );
+//							System.out.println( "Found " + searchRadiusEstimationWindow.getUsedPointsIndexes().size() + " neighbors within the search window but we require " + numNearestNeighbors + " nearest neighbors, perform a K-nearest neighbor search instead..." );
 							System.out.println();
 							System.out.println( pairOfTiles + ": found " + tilesSearchRadius[ j ].getUsedPointsIndexes().size() + " neighbors within the search window of the " + ( j == 0 ? "fixed" : "moving" ) + " tile but we require at least " + minNumNearestNeighbors + " nearest neighbors, so ignore this tile pair for now" );
 							System.out.println();
@@ -548,12 +551,23 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 				// prepare images
 				for ( int j = 0; j < pair.length; j++ )
 				{
-					System.out.println( "Averaging corresponding tile images for " + job.getChannels() + " channels" );
+					if ( job.getArgs().registrationChannelIndex() != null )
+						System.out.println( "Using the channel " + PathResolver.getFileName( job.getArgs().inputTileConfigurations().get( job.getArgs().registrationChannelIndex() ) ) + " for stitching" );
+					else
+						System.out.println( "Averaging corresponding tile images for " + job.getChannels() + " channels" );
+
 //					final ComparableTuple< Integer > coordinates = new ComparableTuple<>( Conversions.toBoxedArray( Utils.getTileCoordinates( pair[ j ] ) ) );
 					final Integer tileIndex = pair[ j ].getIndex();
 					int channelsUsed = 0;
+
+					final List< Integer > channelIndices;
+					if ( job.getArgs().registrationChannelIndex() != null )
+						channelIndices = Collections.singletonList( job.getArgs().registrationChannelIndex() ); // only the specified channel
+					else
+						channelIndices = IntStream.range( 0, job.getChannels() ).boxed().collect( Collectors.toList() ); // all channels
+
 					final ImagePlusImg< FloatType, ? > dst = ImagePlusImgs.floats( Intervals.dimensionsAsLongArray( overlaps[ j ] ) );
-					for ( int channel = 0; channel < job.getChannels(); channel++ )
+					for ( final int channel : channelIndices )
 					{
 						final TileInfo tileInfo = broadcastedTileChannelMappingByIndex.value().get( channel ).get( tileIndex );
 //						for ( final TileInfo tile : job.getTiles( channel ) )
@@ -611,10 +625,14 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 					if ( channelsUsed == 0 )
 						throw new PipelineExecutionException( pairOfTiles + ": images are missing in all channels" );
 
-					final FloatType denom = new FloatType( channelsUsed );
-					final Cursor< FloatType > dstCursor = Views.iterable( dst ).cursor();
-					while ( dstCursor.hasNext() )
-						dstCursor.next().div( denom );
+					// normalize if needed
+					if ( channelsUsed > 1 )
+					{
+						final FloatType denom = new FloatType( channelsUsed );
+						final Cursor< FloatType > dstCursor = Views.iterable( dst ).cursor();
+						while ( dstCursor.hasNext() )
+							dstCursor.next().div( denom );
+					}
 
 					if ( blurSigma > 0 )
 					{

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -29,6 +29,10 @@ public class StitchingArguments implements Serializable {
 			usage = "Path/link to a tile configuration JSON file. Multiple configurations can be passed at once.")
 	private List< String > inputTileConfigurations;
 
+	@Option(name = "-r", aliases = { "--registrationChannelIndex" }, required = false,
+			usage = "Index of the input channel to be used for registration. If omitted, all the input channels will be used for registration (by averaging the tile images).")
+	private Integer registrationChannelIndex = null;
+
 	@Option(name = "-n", aliases = { "--minNeighbors" }, required = false,
 			usage = "Min neighborhood for estimating confidence intervals using offset statistics")
 	private int minStatsNeighborhood = 5;
@@ -122,6 +126,9 @@ public class StitchingArguments implements Serializable {
 		for ( int i = 0; i < inputTileConfigurations.size(); ++i )
 			if ( !CloudURI.isCloudURI( inputTileConfigurations.get( i ) ) )
 				inputTileConfigurations.set( i, Paths.get( inputTileConfigurations.get( i ) ).toAbsolutePath().toString() );
+
+		if ( registrationChannelIndex != null && ( registrationChannelIndex < 0 || registrationChannelIndex >= inputTileConfigurations.size() ) )
+			throw new IllegalArgumentException( "Registration channel index " + registrationChannelIndex + " is out of bounds [0-" + ( inputTileConfigurations.size() - 1 ) + "]" );
 	}
 
 	protected StitchingArguments() { }
@@ -143,6 +150,7 @@ public class StitchingArguments implements Serializable {
 	}
 
 	public List< String > inputTileConfigurations() { return inputTileConfigurations; }
+	public Integer registrationChannelIndex() { return registrationChannelIndex; }
 	public int minStatsNeighborhood() { return minStatsNeighborhood; }
 	public int fusionCellSize() { return fusionCellSize; }
 	public double blurSigma() { return blurSigma; }

--- a/src/main/java/org/janelia/stitching/StitchingJob.java
+++ b/src/main/java/org/janelia/stitching/StitchingJob.java
@@ -105,6 +105,10 @@ public class StitchingJob implements Serializable {
 		return tilesMultichannel.get( channel );
 	}
 
+	public int getMainChannelIndex() {
+		return args.registrationChannelIndex() != null ? args.registrationChannelIndex() : 0;
+	}
+
 	public void setTiles( final TileInfo[] tiles, final int channel ) throws Exception {
 		tilesMultichannel.set( channel, tiles );
 		checkTilesConfiguration();

--- a/src/main/java/org/janelia/stitching/StitchingOptimizer.java
+++ b/src/main/java/org/janelia/stitching/StitchingOptimizer.java
@@ -109,7 +109,7 @@ public class StitchingOptimizer implements Serializable
 	{
 		final DataProvider dataProvider = job.getDataProvider();
 
-		final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( 0 ) );
+		final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) );
 		final String iterationDirname = "iter" + iteration;
 		final String pairwiseShiftsPath = PathResolver.get( basePath, iterationDirname, "pairwise.json" );
 
@@ -123,8 +123,8 @@ public class StitchingOptimizer implements Serializable
 		{
 			try ( final PrintWriter logWriter = new PrintWriter( logOut ) )
 			{
-				logWriter.println( "Tiles total per channel: " + job.getTiles( 0 ).length );
-				System.out.println( "Stitching iteration " + iteration + ": Tiles total per channel: " + job.getTiles( 0 ).length );
+				logWriter.println( "Tiles total per channel: " + job.getTiles( job.getMainChannelIndex() ).length );
+				System.out.println( "Stitching iteration " + iteration + ": Tiles total per channel: " + job.getTiles( job.getMainChannelIndex() ).length );
 
 				final double maxAllowedError = getMaxAllowedError( iteration );
 				logWriter.println( "Set max allowed error to " + maxAllowedError + "px" );
@@ -158,9 +158,6 @@ public class StitchingOptimizer implements Serializable
 						}
 					}
 
-	//				if ( newTiles.size() + optimizationPerformer.lostTiles.size() != tilesMap.size() )
-	//					throw new RuntimeException( "Number of stitched tiles does not match" );
-
 					// sort the tiles by their index
 					final TileInfo[] tilesToSave = Utils.createTilesMap( newTiles.toArray( new TileInfo[ 0 ] ) ).values().toArray( new TileInfo[ 0 ] );
 					TileOperations.translateTilesToOriginReal( tilesToSave );
@@ -175,7 +172,7 @@ public class StitchingOptimizer implements Serializable
 				}
 
 				// save final pairwise shifts configuration (pairs that have been used on the final step of the optimization routine)
-				final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( job.getTiles( 0 ) );
+				final Map< Integer, TileInfo > tilesMap = Utils.createTilesMap( job.getTiles( job.getMainChannelIndex() ) );
 				final Map< Integer, ? extends Map< Integer, SerializablePairWiseStitchingResult[] > > initialShiftsMap = Utils.createPairwiseShiftsMultiMap( shifts, false );
 				final List< SerializablePairWiseStitchingResult[] > usedPairwiseShifts = new ArrayList<>();
 				final List< SerializablePairWiseStitchingResult[] > finalPairwiseShifts = new ArrayList<>();
@@ -241,7 +238,7 @@ public class StitchingOptimizer implements Serializable
 				final OptimizationResult optimizationResult = new OptimizationResult(
 						maxAllowedError,
 						optimizationParameters,
-						job.getTiles( 0 ).length,
+						job.getTiles( job.getMainChannelIndex() ).length,
 						optimizationPerformer.remainingGraphSize,
 						validPairs,
 						optimizationPerformer.avgDisplacement,

--- a/src/main/java/org/janelia/stitching/StitchingOptimizer.java
+++ b/src/main/java/org/janelia/stitching/StitchingOptimizer.java
@@ -105,12 +105,11 @@ public class StitchingOptimizer implements Serializable
 		this.sparkContext = sparkContext;
 	}
 
-	public void optimize( final int iteration ) throws IOException
+	public void optimize( final int iteration, final String iterationDirname ) throws IOException
 	{
 		final DataProvider dataProvider = job.getDataProvider();
 
 		final String basePath = PathResolver.getParent( job.getArgs().inputTileConfigurations().get( job.getMainChannelIndex() ) );
-		final String iterationDirname = "iter" + iteration;
 		final String pairwiseShiftsPath = PathResolver.get( basePath, iterationDirname, "pairwise.json" );
 
 		// FIXME: skip if solution already exists?


### PR DESCRIPTION
Implements #7.
The new cmd arg `-r` specifies the index of the input channel to be used for registration. In this mode, the new naming scheme is used for folders where output stitching files for each iteration are stored, such as 'iter0-ch0', 'iter1-ch0', and so on.
In the default mode when data in all channels are averaged for stitching, the old naming scheme is used, such as 'iter0', 'iter1', and so on.