### PR TITLE
Blockwise deconvolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>3.0.0</version>
+			<version>3.2.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>3.2.0-SNAPSHOT</version>
+			<version>3.2.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -3,6 +3,7 @@ package org.janelia.stitching;
 import java.io.Serializable;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -313,7 +314,9 @@ public class DeconvolutionSpark
 					// save the resulting decon block into the N5 dataset for this tile
 					final N5Writer localN5DeconTilesFloatWriter = localDataProvider.createN5Writer( n5DeconTilesFloatPath );
 					final String outputDatasetPath = channelDeconTilesN5DatasetPaths.get( channelIndex ).get( tile.getIndex() );
-					N5Utils.saveBlock( processingBlockDeconImg, localN5DeconTilesFloatWriter, outputDatasetPath );
+					final long[] gridOffset = new long[ processingBlockSize.length ];
+					Arrays.setAll( gridOffset, d -> processingBlockDeconImg.min( d ) / processingBlockSize[ d ] );
+					N5Utils.saveBlock( processingBlockDeconImg, localN5DeconTilesFloatWriter, outputDatasetPath, gridOffset );
 				}
 			);
 

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -253,8 +253,8 @@ public class DeconvolutionSpark
 					final long[] paddedProcessingBlockMin = new long[ processingBlock.numDimensions() ], paddedProcessingBlockMax = new long[ processingBlock.numDimensions() ];
 					for ( int d = 0; d < processingBlock.numDimensions(); ++d )
 					{
-						paddedProcessingBlockMin[ d ] = Math.max( processingBlock.min( d ) - psfImg.dimension( d ) / 2, tileImg.min( d ) );
-						paddedProcessingBlockMax[ d ] = Math.min( processingBlock.max( d ) + psfImg.dimension( d ) / 2, tileImg.max( d ) );
+						paddedProcessingBlockMin[ d ] = Math.max( processingBlock.min( d ) - psfImg.dimension( d ), tileImg.min( d ) );
+						paddedProcessingBlockMax[ d ] = Math.min( processingBlock.max( d ) + psfImg.dimension( d ), tileImg.max( d ) );
 					}
 					final Interval paddedProcessingBlock = new FinalInterval( paddedProcessingBlockMin, paddedProcessingBlockMax );
 

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -156,7 +156,6 @@ public class DeconvolutionSpark
 		try ( final JavaSparkContext sparkContext = new JavaSparkContext( new SparkConf()
 				.setAppName( "DeconvolutionSpark" )
 				.set( "spark.serializer", "org.apache.spark.serializer.KryoSerializer" )
-				.set( "spark.speculation", "true" ) // will restart tasks that run for too long (if decon hangs which may happen occasionally)
 			) )
 		{
 			// load input tile metadata

--- a/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
+++ b/src/main/java/org/janelia/stitching/DeconvolutionSpark.java
@@ -424,6 +424,9 @@ public class DeconvolutionSpark
 					}
 				);
 
+				// delete N5 container for intermediate 32-bit decon
+				n5DeconTilesFloatWriter.remove();
+
 				// create resulting tile configuration for decon N5 converted output
 				channelDeconTilesMap = new ArrayList<>();
 				for ( int ch = 0; ch < inputTileChannels.size(); ++ch )

--- a/src/main/java/org/janelia/stitching/TileLoader.java
+++ b/src/main/java/org/janelia/stitching/TileLoader.java
@@ -26,7 +26,7 @@ public class TileLoader
 
 	public static TileType getTileType( final TileInfo tile, final DataProvider dataProvider )
 	{
-		final String n5Path  = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) );
+		final String n5Path = PathResolver.getParent( PathResolver.getParent( tile.getFilePath() ) ); // n5 tiles are stored this way: /some/path/tiles.n5/ch0/tile0 (tile0 is a dataset, tiles.n5 is the N5 root)
 		final String tileDatasetPath = Paths.get( n5Path ).relativize( Paths.get( tile.getFilePath() ) ).toString();
 
 		try


### PR DESCRIPTION
Instead of running deconvolution on full tiles, parallelize over smaller blocks.
* Works with large fields of view without the risk of running out of memory.
* Fully utilizes Spark nodes because now there are many small parallel tasks
* Saves to N5 instead of TIFF