### PR TITLE
Fill value in exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ spark-local/export.py -i 488nm-n5-final.json -i 560nm-n5-final.json ...
 
 This will generate an [N5](https://github.com/saalfeldlab/n5) export under `export.n5/` folder. The export is fully compatible  with [N5 Viewer](https://github.com/saalfeldlab/n5-viewer) for browsing.
 
+The most common optional parameters are:
+* `--blending`: smoothes transitions between the tiles instead of making a hard cut between them
+* `--fill`: fills the extra space with the background intensity value instead of 0
+
 The full list of available parameters for the export script is available [here](https://github.com/saalfeldlab/stitching-spark/wiki/Export-parameters).
 
 ### 7. Converting N5 export to slice TIFF

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-spark</artifactId>
-			<version>3.4.0</version>
+			<version>3.4.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-spark</artifactId>
-			<version>3.3.1</version>
+			<version>3.4.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.0</version>
+			<version>2.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
@@ -146,7 +146,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>3.2.0</version>
+			<version>3.4.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>

--- a/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
+++ b/src/main/java/org/janelia/flatfield/FlatfieldCorrection.java
@@ -131,9 +131,12 @@ public class FlatfieldCorrection implements Serializable, AutoCloseable
 		return dst;
 	}
 
-	public static double getPivotValue( final DataProvider dataProvider, final String basePath ) throws IOException
+	public static Double getPivotValue( final DataProvider dataProvider, final String basePath ) throws IOException
 	{
-		return dataProvider.createN5Reader( getFlatfieldFolderForBasePath( basePath ) ).getAttribute( "/", pivotValueAttributeKey, Double.class );
+		final String flatfieldFolderPath = getFlatfieldFolderForBasePath( basePath );
+		if ( !dataProvider.fileExists( flatfieldFolderPath ) )
+			return null;
+		return dataProvider.createN5Reader( flatfieldFolderPath ).getAttribute( "/", pivotValueAttributeKey, Double.class );
 	}
 
 	protected static String getFlatfieldFolderForBasePath( final String basePath )

--- a/src/main/java/org/janelia/stitching/FusionPerformer.java
+++ b/src/main/java/org/janelia/stitching/FusionPerformer.java
@@ -56,9 +56,10 @@ public class FusionPerformer
 			final DataProvider dataProvider,
 			final FusionMode mode,
 			final List< TileInfo > tilesWithinCell,
-			final Interval targetInterval ) throws Exception
+			final Interval targetInterval,
+			final Number backgroundValue ) throws Exception
 	{
-		return fuseTilesWithinCell( dataProvider, mode, tilesWithinCell, targetInterval, null );
+		return fuseTilesWithinCell( dataProvider, mode, tilesWithinCell, targetInterval, backgroundValue, null );
 	}
 
 	public static <
@@ -69,9 +70,10 @@ public class FusionPerformer
 			final FusionMode mode,
 			final List< TileInfo > tilesWithinCell,
 			final Interval targetInterval,
+			final Number backgroundValue,
 			final RandomAccessiblePairNullable< U, U > flatfield ) throws Exception
 	{
-		return fuseTilesWithinCell( dataProvider, mode, tilesWithinCell, targetInterval, flatfield, null );
+		return fuseTilesWithinCell( dataProvider, mode, tilesWithinCell, targetInterval, backgroundValue, flatfield, null );
 	}
 
 	public static <
@@ -83,15 +85,16 @@ public class FusionPerformer
 			final FusionMode mode,
 			final List< TileInfo > tilesWithinCell,
 			final Interval targetInterval,
+			final Number backgroundValue,
 			final RandomAccessiblePairNullable< U, U > flatfield,
 			final Map< Integer, Set< Integer > > pairwiseConnectionsMap ) throws Exception
 	{
 		switch ( mode )
 		{
 		case MAX_MIN_DISTANCE:
-			return fuseTilesWithinCellUsingMaxMinDistance( dataProvider, tilesWithinCell, targetInterval, flatfield, pairwiseConnectionsMap );
+			return fuseTilesWithinCellUsingMaxMinDistance( dataProvider, tilesWithinCell, targetInterval, backgroundValue, flatfield, pairwiseConnectionsMap );
 		case BLENDING:
-			return fuseTilesWithinCellUsingBlending( dataProvider, tilesWithinCell, targetInterval, flatfield, pairwiseConnectionsMap );
+			return fuseTilesWithinCellUsingBlending( dataProvider, tilesWithinCell, targetInterval, backgroundValue, flatfield, pairwiseConnectionsMap );
 		default:
 			throw new RuntimeException( "Unknown fusion mode" );
 		}
@@ -106,6 +109,7 @@ public class FusionPerformer
 			final DataProvider dataProvider,
 			final List< TileInfo > tilesWithinCell,
 			final Interval targetInterval,
+			final Number backgroundValue,
 			final RandomAccessiblePairNullable< U, U > flatfield,
 			final Map< Integer, Set< Integer > > pairwiseConnectionsMap ) throws Exception
 	{
@@ -214,8 +218,12 @@ public class FusionPerformer
 			}
 		}
 
+		final T fillType = ( T ) imageType.getType().createVariable();
+		if ( backgroundValue != null)
+			fillType.setReal( backgroundValue.doubleValue() );
+
 		// initialize output image
-		final ImagePlusImg< T, ? > out = new ImagePlusImgFactory< T >().create( Intervals.dimensionsAsLongArray( targetInterval ), ( T ) imageType.getType().createVariable() );
+		final ImagePlusImg< T, ? > out = new ImagePlusImgFactory< T >().create( Intervals.dimensionsAsLongArray( targetInterval ), fillType.createVariable() );
 		final Cursor< FloatType > weightsCursor = Views.flatIterable( weights ).cursor();
 		final Cursor< FloatType > valuesCursor = Views.flatIterable( values ).cursor();
 		final Cursor< T > outCursor = Views.flatIterable( out ).cursor();
@@ -223,7 +231,7 @@ public class FusionPerformer
 		{
 			final double weight = weightsCursor.next().getRealDouble();
 			final double value = valuesCursor.next().getRealDouble();
-			outCursor.next().setReal( weight == 0 ? 0 : value / weight );
+			outCursor.next().setReal( weight == 0 ? fillType.getRealDouble() : value / weight );
 		}
 
 		// retain only requested content within overlaps that corresponds to pairwise connections map
@@ -247,7 +255,7 @@ public class FusionPerformer
 
 				outCursor.fwd();
 				if ( !retainPixel )
-					outCursor.get().setZero();
+					outCursor.get().set( fillType );
 			}
 		}
 
@@ -284,19 +292,6 @@ public class FusionPerformer
 			return ( Math.cos( (1 - minDistance) * Math.PI ) + 1 ) / 2;
 	}
 
-
-	/**
-	 * Fuses a collection of {@link TileInfo} objects within the given target interval using hard-cut strategy in overlaps.
-	 *
-	 * @param tilesWithinCell
-	 * 			A list of tiles that have non-empty intersection with the target interval
-	 * @param targetInterval
-	 * 			An output fusion cell
-	 * @param interpolatorFactory
-	 * 			An interpolation strategy for tiles with real coordinates
-	 * @param flatfieldCorrection
-	 * 			Optional flatfield correction coefficients (can be null)
-	 */
 	public static <
 		T extends RealType< T > & NativeType< T >,
 		U extends RealType< U > & NativeType< U >,
@@ -305,6 +300,7 @@ public class FusionPerformer
 			final DataProvider dataProvider,
 			final List< TileInfo > tilesWithinCell,
 			final Interval targetInterval,
+			final Number backgroundValue,
 			final RandomAccessiblePairNullable< U, U > flatfield,
 			final Map< Integer, Set< Integer > > pairwiseConnectionsMap ) throws Exception
 	{
@@ -312,12 +308,20 @@ public class FusionPerformer
 		if ( imageType == null )
 			throw new Exception( "Can't fuse images of different or unknown types" );
 
+		final T fillType = ( T ) imageType.getType().createVariable();
+		if ( backgroundValue != null)
+			fillType.setReal( backgroundValue.doubleValue() );
+
 		// initialize output image
-		final ImagePlusImg< T, ? > out = new ImagePlusImgFactory< T >().create( Intervals.dimensionsAsLongArray( targetInterval ), ( T ) imageType.getType().createVariable() );
+		final ImagePlusImg< T, ? > out = new ImagePlusImgFactory< T >().create( Intervals.dimensionsAsLongArray( targetInterval ), fillType.createVariable() );
+
+		// fill with default value
+		if ( backgroundValue != null )
+			for ( final T outVal : out )
+				outVal.set( fillType );
 
 		// initialize helper image for hard-cut fusion strategy
-		final RandomAccessibleInterval< FloatType > maxMinDistances = ArrayImgs.floats(
-				Intervals.dimensionsAsLongArray( targetInterval ) );
+		final RandomAccessibleInterval< FloatType > maxMinDistances = ArrayImgs.floats( Intervals.dimensionsAsLongArray( targetInterval ) );
 
 		// initialize helper image for tile connections when exporting only overlaps
 		final RandomAccessibleInterval< Set< Integer > > tileIndexes;
@@ -440,7 +444,7 @@ public class FusionPerformer
 
 				outCursor.fwd();
 				if ( !retainPixel )
-					outCursor.get().setZero();
+					outCursor.get().set( fillType );
 			}
 		}
 

--- a/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
+++ b/src/main/java/org/janelia/stitching/N5ToSliceTiffSpark.java
@@ -3,6 +3,7 @@ package org.janelia.stitching;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -118,6 +119,10 @@ public class N5ToSliceTiffSpark
 				}
 				final String sliceIndexFormat = parsedArgs.useLeadingZeroes ? "%05d" : "%d";
 				final String filenameFormat = filenamePrefix + sliceIndexFormat + ".tif";
+
+				// load fill intensity value from n5 export attributes if a custom value was used
+				final Number fillValue = PipelineFusionStepExecutor.getBackgroundValue( n5, channel );
+
 				org.janelia.saalfeldlab.n5.spark.N5ToSliceTiffSpark.convert(
 						sparkContext,
 						() -> {
@@ -131,7 +136,8 @@ public class N5ToSliceTiffSpark
 						outputChannelPath,
 						tiffCompression,
 						SliceDimension.Z,
-						filenameFormat
+						filenameFormat,
+						Optional.ofNullable( fillValue )
 					);
 			}
 		}

--- a/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineFusionStepExecutor.java
@@ -306,7 +306,7 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 		sparkContext.parallelize( processingCells, Math.min( processingCells.size(), MAX_PARTITIONS ) ).foreach( cell ->
 			{
 				final List< TileInfo > tilesWithinCell = TileOperations.findTilesWithinSubregion( tiles, cell );
-				if ( tilesWithinCell.isEmpty() )
+				if ( tilesWithinCell.isEmpty() && backgroundValue == null )
 					return;
 
 				final Boundaries cellBox = cell.getBoundaries();
@@ -319,11 +319,14 @@ public class PipelineFusionStepExecutor< T extends NativeType< T > & RealType< T
 				cellGrid.getCellPosition( cellOffsetCoordinates, cellGridPosition );
 
 				final DataProvider dataProviderLocal = job.getDataProvider();
+				final T dataType = ( T ) tiles[ 0 ].getType().getType();
+
 				final ImagePlusImg< T, ? > outImg = FusionPerformer.fuseTilesWithinCell(
 						dataProviderLocal,
 						job.getArgs().blending() ? FusionMode.BLENDING : FusionMode.MAX_MIN_DISTANCE,
 						tilesWithinCell,
 						cellBox,
+						dataType,
 						backgroundValue,
 						broadcastedFlatfieldCorrection.value(),
 						broadcastedPairwiseConnectionsMap.value()

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -83,7 +83,7 @@ public class StitchingArguments implements Serializable {
 			usage = "Export the dataset using blending strategy instead of hardcut (max.min.distance)")
 	private boolean blending = false;
 
-	@Option(name = "--fillBackground", required = false,
+	@Option(name = "--fillBackground", aliases = { "--fill" }, required = false,
 			usage = "Fill the outer space in N5 export with the background value of the data instead of zero")
 	private boolean fillBackground = false;
 

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -83,6 +83,10 @@ public class StitchingArguments implements Serializable {
 			usage = "Export the dataset using blending strategy instead of hardcut (max.min.distance)")
 	private boolean blending = false;
 
+	@Option(name = "--fillBackground", required = false,
+			usage = "Fill the outer space in N5 export with the background value of the data instead of zero")
+	private boolean fillBackground = false;
+
 	/**
 	 * Toggle pipeline stages. By default all stages are executed.
 	 */
@@ -167,6 +171,7 @@ public class StitchingArguments implements Serializable {
 	public boolean noLeaves() { return noLeaves; }
 	public boolean exportOverlaps() { return exportOverlaps; }
 	public boolean blending() { return blending; }
+	public boolean fillBackground() { return fillBackground; }
 	public boolean allowFusingStage() { return allowFusingStage; }
 
 	public boolean stitchOnly() { return stitchOnly; }


### PR DESCRIPTION
Adds the option `--fill` in `export.py` script to fill the extra space in stitched exports with the background value instead of 0.
* For raw data, the background value is retrieved from the flatfield attributes (which could be either estimated or user-specified value)
* For deconvolved data, the background intensity is estimated automatically in each channel (similar to how it's estimated for raw data in the flatfield step)