### PR TITLE
Improve stitching robustness

### DIFF
--- a/src/main/java/org/janelia/stitching/StitchingOptimizer.java
+++ b/src/main/java/org/janelia/stitching/StitchingOptimizer.java
@@ -108,11 +108,14 @@ public class StitchingOptimizer implements Serializable
 			if ( remainingGraphSize != other.remainingGraphSize )
 				return -Integer.compare( remainingGraphSize, other.remainingGraphSize );
 
-			/*
-			// better when the resulting graph has more edges
-			if ( remainingPairs != other.remainingPairs )
-				return -Integer.compare( remainingPairs, other.remainingPairs );
-			*/
+			// additionally consider the remaining number of pairwise connections if the max error is within the acceptable range (no more than 10px)
+			// it's better when the resulting graph has more edges (the solution may be more stable)
+			if ( Math.round( maxAllowedError ) <= 10 )
+			{
+				// better when the resulting graph has more edges
+				if ( remainingPairs != other.remainingPairs )
+					return -Integer.compare( remainingPairs, other.remainingPairs );
+			}
 
 			// if everything above is the same, the order is determined by smaller or higher error
 			return Double.compare( maxDisplacement, other.maxDisplacement );

--- a/src/main/java/org/janelia/stitching/StitchingOptimizer.java
+++ b/src/main/java/org/janelia/stitching/StitchingOptimizer.java
@@ -53,16 +53,16 @@ public class StitchingOptimizer implements Serializable
 	private static final class OptimizationResult implements Comparable< OptimizationResult >
 	{
 		public final OptimizationParameters optimizationParameters;
-		public final double score;
-
+		public final double maxAllowedError;
+		public final int fullGraphSize;
 		public final int remainingGraphSize;
 		public final int remainingPairs;
 		public final double maxDisplacement;
 		public final double avgDisplacement;
 
 		public OptimizationResult(
-				final double maxAllowedError,
 				final OptimizationParameters optimizationParameters,
+				final double maxAllowedError,
 				final int fullGraphSize,
 				final int remainingGraphSize,
 				final int remainingPairs,
@@ -70,20 +70,12 @@ public class StitchingOptimizer implements Serializable
 				final double maxDisplacement )
 		{
 			this.optimizationParameters = optimizationParameters;
+			this.maxAllowedError = maxAllowedError;
+			this.fullGraphSize = fullGraphSize;
 			this.remainingGraphSize = remainingGraphSize;
 			this.remainingPairs = remainingPairs;
 			this.avgDisplacement = avgDisplacement;
 			this.maxDisplacement = maxDisplacement;
-
-			final double remainingGraphToFullGraphRatio = ( double ) remainingGraphSize / fullGraphSize;
-			assert remainingGraphToFullGraphRatio >= 0 && remainingGraphToFullGraphRatio <= 0;
-
-//			assert maxDisplacement >= 0;
-//			final double displacementScore = 1 - maxDisplacement / MAX_DISPLACEMENT_LIMIT;
-//
-//			score = remainingGraphToFullGraphRatio * displacementScore;
-
-			score = remainingGraphSize == 0 || maxDisplacement > maxAllowedError ? Double.NEGATIVE_INFINITY : remainingGraphToFullGraphRatio;
 		}
 
 		/*
@@ -92,7 +84,38 @@ public class StitchingOptimizer implements Serializable
 		@Override
 		public int compareTo( final OptimizationResult other )
 		{
-			return Double.compare( other.score, score );
+			// if both are above the error threshold, the order is determined by the resulting graph size and max.error
+			if ( maxDisplacement > maxAllowedError && other.maxDisplacement > other.maxAllowedError )
+			{
+				if ( remainingGraphSize != other.remainingGraphSize )
+					return -Integer.compare( remainingGraphSize, other.remainingGraphSize );
+
+				return Double.compare( maxDisplacement, other.maxDisplacement );
+			}
+			// otherwise, the one that is above the error threshold goes last
+			else if ( maxDisplacement > maxAllowedError )
+			{
+				return 1;
+			}
+			else if ( other.maxDisplacement > other.maxAllowedError )
+			{
+				return -1;
+			}
+
+			// both are within the accepted error range
+
+			// better if the resulting graph is larger
+			if ( remainingGraphSize != other.remainingGraphSize )
+				return -Integer.compare( remainingGraphSize, other.remainingGraphSize );
+
+			/*
+			// better when the resulting graph has more edges
+			if ( remainingPairs != other.remainingPairs )
+				return -Integer.compare( remainingPairs, other.remainingPairs );
+			*/
+
+			// if everything above is the same, the order is determined by smaller or higher error
+			return Double.compare( maxDisplacement, other.maxDisplacement );
 		}
 	}
 
@@ -235,8 +258,8 @@ public class StitchingOptimizer implements Serializable
 				final GlobalOptimizationPerformer optimizationPerformer = new GlobalOptimizationPerformer();
 				optimizationPerformer.optimize( comparePairs, broadcastedStitchingParameters.value() );
 				final OptimizationResult optimizationResult = new OptimizationResult(
-						maxAllowedError,
 						optimizationParameters,
+						maxAllowedError,
 						job.getTiles( job.getMainChannelIndex() ).length,
 						optimizationPerformer.remainingGraphSize,
 						validPairs,
@@ -273,7 +296,7 @@ public class StitchingOptimizer implements Serializable
 			logWriter.println();
 			for ( final OptimizationResult optimizationResult : optimizationResultList )
 				logWriter.println(
-						"score=" + String.format( "%.2f", optimizationResult.score ) +
+						"ratio=" + String.format( "%.2f", ( double ) optimizationResult.remainingGraphSize / optimizationResult.fullGraphSize ) +
 						", graph=" + optimizationResult.remainingGraphSize +
 						", pairs=" + optimizationResult.remainingPairs +
 						", avg.error=" + String.format( "%.2f", optimizationResult.avgDisplacement ) +

--- a/src/main/java/org/janelia/stitching/analysis/ComparePairwiseCorrelations.java
+++ b/src/main/java/org/janelia/stitching/analysis/ComparePairwiseCorrelations.java
@@ -1,0 +1,65 @@
+package org.janelia.stitching.analysis;
+
+import javafx.util.Pair;
+import net.imglib2.util.SerializablePair;
+import net.imglib2.util.ValuePair;
+import org.janelia.dataaccess.DataProvider;
+import org.janelia.dataaccess.DataProviderFactory;
+import org.janelia.dataaccess.PathResolver;
+import org.janelia.stitching.SerializablePairWiseStitchingResult;
+import org.janelia.stitching.TileInfo;
+import org.janelia.stitching.TileInfoJSONProvider;
+import org.janelia.stitching.Utils;
+
+import java.io.IOException;
+import java.util.*;
+
+public class ComparePairwiseCorrelations
+{
+    public static void main( final String[] args ) throws Exception
+    {
+        if ( args.length != 2 )
+            throw new IllegalArgumentException( "Can compare only two pairwise configuration files" );
+        final String configA = args[ 0 ], configB = args[ 1 ];
+        final DataProvider dataProvider = DataProviderFactory.create( DataProviderFactory.detectType( configA ) );
+        final List< SerializablePairWiseStitchingResult > shiftsA = loadPairwiseShifts( dataProvider, configA );
+        final List< SerializablePairWiseStitchingResult > shiftsB = loadPairwiseShifts( dataProvider, configB );
+        System.out.println( "A size: "  + shiftsA.size() + ", B size: " + shiftsB.size() + System.lineSeparator() );
+
+        final Map< Integer, ? extends Map< Integer, SerializablePairWiseStitchingResult > > shiftsMapB = Utils.createPairwiseShiftsMap( shiftsB, false );
+        for ( final SerializablePairWiseStitchingResult shiftA : shiftsA )
+        {
+            final int ind1 = Math.min( shiftA.getTilePair().getA().getIndex(), shiftA.getTilePair().getB().getIndex() );
+            final int ind2 = Math.max( shiftA.getTilePair().getA().getIndex(), shiftA.getTilePair().getB().getIndex() );
+
+            if ( !shiftsMapB.containsKey( ind1 ) || !shiftsMapB.get( ind1 ).containsKey( ind2 ) )
+            {
+                System.out.println( shiftA.getTilePair() + ": shift not found in config 2" );
+                continue;
+            }
+
+            final SerializablePairWiseStitchingResult shiftB = shiftsMapB.get( ind1 ).get( ind2 );
+            System.out.println( String.format(
+                    "%s:   config1 cr.corr=%.2f, valid=%b   config2 cr.corr=%.2f, valid=%b",
+                    shiftA.getTilePair().toString(),
+                    shiftA.getCrossCorrelation(),
+                    shiftA.getIsValidOverlap(),
+                    shiftB.getCrossCorrelation(),
+                    shiftB.getIsValidOverlap()
+                ) );
+        }
+
+        System.out.println( System.lineSeparator() + "-----------------------" + System.lineSeparator() + "Done" );
+    }
+
+    private static List< SerializablePairWiseStitchingResult > loadPairwiseShifts( final DataProvider dataProvider, final String pairwiseShiftsPath ) throws IOException
+    {
+        // pairwise shifts are currently as array (several different peaks are supported for a tile pair),
+        // but the stitching code currently exports only one peak
+        final List< SerializablePairWiseStitchingResult > shifts = new ArrayList<>();
+        final List< SerializablePairWiseStitchingResult[] > pairwiseShiftsMultiPeaks = TileInfoJSONProvider.loadPairwiseShiftsMulti( dataProvider.getJsonReader( pairwiseShiftsPath ) );
+        for ( final SerializablePairWiseStitchingResult[] pairwiseShiftMultiPeaks : pairwiseShiftsMultiPeaks )
+            shifts.add( pairwiseShiftMultiPeaks[ 0 ] ); // simply take the first peak
+        return shifts;
+    }
+}

--- a/src/main/java/org/janelia/stitching/analysis/ComparePairwiseCorrelations.java
+++ b/src/main/java/org/janelia/stitching/analysis/ComparePairwiseCorrelations.java
@@ -1,18 +1,15 @@
 package org.janelia.stitching.analysis;
 
-import javafx.util.Pair;
-import net.imglib2.util.SerializablePair;
-import net.imglib2.util.ValuePair;
 import org.janelia.dataaccess.DataProvider;
 import org.janelia.dataaccess.DataProviderFactory;
-import org.janelia.dataaccess.PathResolver;
 import org.janelia.stitching.SerializablePairWiseStitchingResult;
-import org.janelia.stitching.TileInfo;
 import org.janelia.stitching.TileInfoJSONProvider;
 import org.janelia.stitching.Utils;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class ComparePairwiseCorrelations
 {


### PR DESCRIPTION
* convert preprocessed ROI images to original data type before computing correlations
(more likely to choose a good phase correlation peak when inputs are uint16 instead of float)
* consider number of remaining pairwise connections in resulting solutions when sorting them
(solutions with higher number of retained edges are more likely to be correct)