### PR TITLE
Command line arguments to set the search path for flatfield correction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .project
 .settings
 
+# Intellij files
+.idea
+
 *.class
 dependency-reduced-pom.xml
 

--- a/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
+++ b/src/main/java/org/janelia/stitching/PipelineStitchingStepExecutor.java
@@ -393,7 +393,7 @@ public class PipelineStitchingStepExecutor extends PipelineStepExecutor
 
 		System.out.println( "Broadcasting flatfield correction images" );
 		final List< RandomAccessiblePairNullable< U, U > > flatfieldCorrectionForChannels = new ArrayList<>();
-		for ( final String channelPath : job.getArgs().inputTileConfigurations() )
+		for ( final String channelPath : job.getArgs().correctionImagesPaths() )
 			flatfieldCorrectionForChannels.add( FlatfieldCorrection.loadCorrectionImages( dataProvider, channelPath, job.getDimensionality() ) );
 		final Broadcast< List< RandomAccessiblePairNullable< U, U > > > broadcastedFlatfieldCorrectionForChannels = sparkContext.broadcast( flatfieldCorrectionForChannels );
 

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -140,13 +140,11 @@ public class StitchingArguments implements Serializable {
 			if ( !CloudURI.isCloudURI( inputTileConfigurations.get( i ) ) )
 				inputTileConfigurations.set( i, Paths.get( inputTileConfigurations.get( i ) ).toAbsolutePath().toString() );
 
-		if (correctionImagesPaths != null && correctionImagesPaths.size() > 0)
+		if (correctionImagesPaths != null && correctionImagesPaths.size() > 0) {
 			if (correctionImagesPaths.size() != inputTileConfigurations.size())
 				throw new IllegalArgumentException("Correction images must match input tile configurations");
-			else
-			{
-				correctionImagesPaths = new ArrayList<>(inputTileConfigurations);
-			}
+		} else
+			correctionImagesPaths = new ArrayList<>(inputTileConfigurations);
 
 		if ( !fuseOnly )
 		{

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -2,6 +2,7 @@ package org.janelia.stitching;
 
 import java.io.Serializable;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.janelia.dataaccess.CloudURI;
@@ -28,6 +29,10 @@ public class StitchingArguments implements Serializable {
 	@Option(name = "-i", aliases = { "--input" }, required = true,
 			usage = "Path/link to a tile configuration JSON file. Multiple configurations can be passed at once.")
 	private List< String > inputTileConfigurations;
+
+	@Option(name = "--correction-images-paths", required = false,
+			usage = "Path/link to correction images")
+	private List< String > correctionImagesPaths;
 
 	@Option(name = "-r", aliases = { "--registrationChannelIndex" }, required = false,
 			usage = "Index of the input channel to be used for registration (indexing starts from 0). If omitted or equal to -1, all input channels will be used for registration by averaging the tile images.")
@@ -135,6 +140,14 @@ public class StitchingArguments implements Serializable {
 			if ( !CloudURI.isCloudURI( inputTileConfigurations.get( i ) ) )
 				inputTileConfigurations.set( i, Paths.get( inputTileConfigurations.get( i ) ).toAbsolutePath().toString() );
 
+		if (correctionImagesPaths != null && correctionImagesPaths.size() > 0)
+			if (correctionImagesPaths.size() != inputTileConfigurations.size())
+				throw new IllegalArgumentException("Correction images must match input tile configurations");
+			else
+			{
+				correctionImagesPaths = new ArrayList<>(inputTileConfigurations);
+			}
+
 		if ( !fuseOnly )
 		{
 			if ( registrationChannelIndex != null && registrationChannelIndex == -1 )
@@ -163,6 +176,7 @@ public class StitchingArguments implements Serializable {
 	}
 
 	public List< String > inputTileConfigurations() { return inputTileConfigurations; }
+	public List< String > correctionImagesPaths() { return correctionImagesPaths; }
 	public Integer registrationChannelIndex() { return registrationChannelIndex; }
 	public int minStatsNeighborhood() { return minStatsNeighborhood; }
 	public int fusionCellSize() { return fusionCellSize; }

--- a/src/main/java/org/janelia/stitching/StitchingArguments.java
+++ b/src/main/java/org/janelia/stitching/StitchingArguments.java
@@ -140,7 +140,8 @@ public class StitchingArguments implements Serializable {
 			if ( !CloudURI.isCloudURI( inputTileConfigurations.get( i ) ) )
 				inputTileConfigurations.set( i, Paths.get( inputTileConfigurations.get( i ) ).toAbsolutePath().toString() );
 
-		if (correctionImagesPaths != null && correctionImagesPaths.size() > 0) {
+		if (correctionImagesPaths != null && correctionImagesPaths.size() > 0)
+		{
 			if (correctionImagesPaths.size() != inputTileConfigurations.size())
 				throw new IllegalArgumentException("Correction images must match input tile configurations");
 		} else


### PR DESCRIPTION
This PR adds extra parameter for stitch and fuse that specify where the flatfield correction are located. This was needed because some pipelines may have a retiling step before stitching and fuseing which renames the results to  `ch<channelnumber>-retiled-n5.json` and the downstream steps will no longer find the flatfield files.